### PR TITLE
Bump package version

### DIFF
--- a/stac_geoparquet/__init__.py
+++ b/stac_geoparquet/__init__.py
@@ -1,5 +1,5 @@
 """stac-geoparquet"""
-__version__ = "0.3.2"
+__version__ = "0.4.1"
 
 from .stac_geoparquet import to_geodataframe, to_dict, to_item_collection
 


### PR DESCRIPTION
This repo isn't set up for automatically getting the version from the tag, so the release failed.