### PR TITLE
Write to Parquet with GeoParquet 1.1 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ module = [
     "pandas.*",
     "pyarrow.*",
     "pypgstac.*",
+    "pyproj.*",
     "rich.*",
     "shapely.*",
     "tqdm.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ module = [
     "pandas.*",
     "pyarrow.*",
     "pypgstac.*",
-    "pyproj.*",
     "rich.*",
     "shapely.*",
     "tqdm.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ module = [
     "pandas.*",
     "pyarrow.*",
     "pypgstac.*",
+    "pyproj.*",
     "rich.*",
     "shapely.*",
     "tqdm.*",

--- a/stac_geoparquet/to_parquet.py
+++ b/stac_geoparquet/to_parquet.py
@@ -7,7 +7,7 @@ from pyproj import CRS
 WGS84_CRS_JSON = CRS.from_epsg(4326).to_json_dict()
 
 
-def to_parquet(table: pa.Table, where, **kwargs):
+def to_parquet(table: pa.Table, where, **kwargs) -> None:
     """Write an Arrow table with STAC data to GeoParquet
 
     This writes metadata compliant with GeoParquet 1.1.

--- a/stac_geoparquet/to_parquet.py
+++ b/stac_geoparquet/to_parquet.py
@@ -1,0 +1,45 @@
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pyproj import CRS
+
+WGS84_CRS_JSON = CRS.from_epsg(4326).to_json_dict()
+
+
+def to_parquet(table: pa.Table, where, **kwargs):
+    """Write an Arrow table with STAC data to GeoParquet
+
+    This writes metadata compliant with GeoParquet 1.1.
+
+    Args:
+        table: The table to write to Parquet
+        where: The destination for saving.
+    """
+    # TODO: include bbox of geometries
+    column_meta = {
+        "encoding": "WKB",
+        # TODO: specify known geometry types
+        "geometry_types": [],
+        "crs": WGS84_CRS_JSON,
+        "edges": "planar",
+        "covering": {
+            "bbox": {
+                "xmin": ["bbox", "xmin"],
+                "ymin": ["bbox", "ymin"],
+                "xmax": ["bbox", "xmax"],
+                "ymax": ["bbox", "ymax"],
+            }
+        },
+    }
+    geo_meta = {
+        "version": "1.1.0-dev",
+        "columns": {"geometry": column_meta},
+        "primary_column": "geometry",
+    }
+
+    metadata = table.schema.metadata
+    metadata.update({b"geo": json.dumps(geo_meta).encode("utf-8")})
+    table = table.replace_schema_metadata(metadata)
+
+    pq.write_table(table, where, **kwargs)

--- a/stac_geoparquet/to_parquet.py
+++ b/stac_geoparquet/to_parquet.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -7,7 +8,7 @@ from pyproj import CRS
 WGS84_CRS_JSON = CRS.from_epsg(4326).to_json_dict()
 
 
-def to_parquet(table: pa.Table, where, **kwargs) -> None:
+def to_parquet(table: pa.Table, where: Any, **kwargs: Any) -> None:
     """Write an Arrow table with STAC data to GeoParquet
 
     This writes metadata compliant with GeoParquet 1.1.

--- a/stac_geoparquet/to_parquet.py
+++ b/stac_geoparquet/to_parquet.py
@@ -38,7 +38,7 @@ def to_parquet(table: pa.Table, where, **kwargs):
         "primary_column": "geometry",
     }
 
-    metadata = table.schema.metadata
+    metadata = table.schema.metadata or {}
     metadata.update({b"geo": json.dumps(geo_meta).encode("utf-8")})
     table = table.replace_schema_metadata(metadata)
 


### PR DESCRIPTION
This adds a wrapper on top of `pyarrow.parquet.write_table` to write an Arrow table to Parquet, including GeoParquet 1.1 metadata for the bbox covering column.

This is done on top of https://github.com/stac-utils/stac-geoparquet/pull/37, but only the last commit should be considered for this PR.