### PR TITLE
Exhaustive schema inference

### DIFF
--- a/stac_geoparquet/arrow/_crs.py
+++ b/stac_geoparquet/arrow/_crs.py
@@ -1,0 +1,3 @@
+from pyproj import CRS
+
+WGS84_CRS_JSON = CRS.from_epsg(4326).to_json_dict()

--- a/stac_geoparquet/arrow/_from_arrow.py
+++ b/stac_geoparquet/arrow/_from_arrow.py
@@ -4,7 +4,7 @@ import json
 import operator
 import os
 from functools import reduce
-from typing import Iterable, List, Sequence, Union
+from typing import Any, Dict, Iterable, List, Sequence, Tuple, Union
 
 import numpy as np
 import pyarrow as pa
@@ -196,7 +196,7 @@ def _convert_bbox_to_array(table: pa.Table) -> pa.Table:
     return table.set_column(bbox_col_idx, "bbox", new_chunks)
 
 
-def convert_tuples_to_lists(t: Sequence):
+def convert_tuples_to_lists(t: List | Tuple) -> List[Any]:
     """Convert tuples to lists, recursively
 
     For example, converts:
@@ -233,17 +233,17 @@ def convert_tuples_to_lists(t: Sequence):
     return list(map(convert_tuples_to_lists, t)) if isinstance(t, (list, tuple)) else t
 
 
-def get_by_path(root, items):
+def get_by_path(root: Dict[str, Any], keys: Sequence[str]) -> Any:
     """Access a nested object in root by item sequence.
 
     From https://stackoverflow.com/a/14692747
     """
-    return reduce(operator.getitem, items, root)
+    return reduce(operator.getitem, keys, root)
 
 
-def set_by_path(root, items, value):
+def set_by_path(root: Dict[str, Any], keys: Sequence[str], value: Any) -> None:
     """Set a value in a nested object in root by item sequence.
 
     From https://stackoverflow.com/a/14692747
     """
-    get_by_path(root, items[:-1])[items[-1]] = value  # type: ignore
+    get_by_path(root, keys[:-1])[keys[-1]] = value  # type: ignore

--- a/stac_geoparquet/arrow/_schema/models.py
+++ b/stac_geoparquet/arrow/_schema/models.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Dict, Iterable, Sequence, Union
 
 import pyarrow as pa
 
@@ -29,8 +29,15 @@ class InferredSchema:
         self,
         path: Union[Union[str, Path], Iterable[Union[str, Path]]],
         *,
-        chunk_size: int = 10000,
+        chunk_size: int = 65536,
     ):
+        """
+        Update this inferred schema from one or more newline-delimited JSON STAC files.
+
+        Args:
+            path: One or more paths to files with STAC items.
+            chunk_size: The chunk size to load into memory at a time. Defaults to 65536.
+        """
         # Handle multi-path input
         if not isinstance(path, (str, Path)):
             for p in path:
@@ -53,7 +60,8 @@ class InferredSchema:
             if len(items) > 0:
                 self.update_from_items(items)
 
-    def update_from_items(self, items: List[Dict[str, Any]]):
+    def update_from_items(self, items: Sequence[Dict[str, Any]]):
+        """Update this inferred schema from a sequence of STAC Items."""
         self.count += len(items)
         current_schema = stac_items_to_arrow(items, schema=None).schema
         new_schema = pa.unify_schemas(

--- a/stac_geoparquet/arrow/_schema/models.py
+++ b/stac_geoparquet/arrow/_schema/models.py
@@ -30,7 +30,7 @@ class InferredSchema:
         path: Union[Union[str, Path], Iterable[Union[str, Path]]],
         *,
         chunk_size: int = 65536,
-    ):
+    ) -> None:
         """
         Update this inferred schema from one or more newline-delimited JSON STAC files.
 
@@ -60,7 +60,7 @@ class InferredSchema:
             if len(items) > 0:
                 self.update_from_items(items)
 
-    def update_from_items(self, items: Sequence[Dict[str, Any]]):
+    def update_from_items(self, items: Sequence[Dict[str, Any]]) -> None:
         """Update this inferred schema from a sequence of STAC Items."""
         self.count += len(items)
         current_schema = stac_items_to_arrow(items, schema=None).schema

--- a/stac_geoparquet/arrow/_schema/models.py
+++ b/stac_geoparquet/arrow/_schema/models.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Union
+
+import pyarrow as pa
+
+from stac_geoparquet.arrow._util import stac_items_to_arrow
+
+
+class InferredSchema:
+    """
+    A schema representing the original STAC JSON with absolutely minimal modifications.
+
+    The only modification from the data is converting any geometry fields from GeoJSON
+    to WKB.
+    """
+
+    inner: pa.Schema
+    """The underlying Arrow schema."""
+
+    count: int
+    """The total number of items scanned."""
+
+    def __init__(self) -> None:
+        self.inner = pa.schema([])
+        self.count = 0
+
+    def update_from_ndjson(
+        self,
+        path: Union[Union[str, Path], Iterable[Union[str, Path]]],
+        *,
+        chunk_size: int = 10000,
+    ):
+        # Handle multi-path input
+        if not isinstance(path, (str, Path)):
+            for p in path:
+                self.update_from_ndjson(p)
+
+            return
+
+        # Handle single-path input
+        with open(path) as f:
+            items = []
+            for line in f:
+                item = json.loads(line)
+                items.append(item)
+
+                if len(items) >= chunk_size:
+                    self.update_from_items(items)
+                    items = []
+
+            # Handle remainder
+            if len(items) > 0:
+                self.update_from_items(items)
+
+    def update_from_items(self, items: List[Dict[str, Any]]):
+        self.count += len(items)
+        current_schema = stac_items_to_arrow(items, schema=None).schema
+        new_schema = pa.unify_schemas(
+            [self.inner, current_schema], promote_options="permissive"
+        )
+        self.inner = new_schema

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -3,7 +3,17 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import ciso8601
 import numpy as np
@@ -76,7 +86,7 @@ def parse_stac_ndjson_to_arrow(
     *,
     chunk_size: int = 65536,
     schema: Optional[Union[pa.Schema, InferredSchema]] = None,
-):
+) -> Iterator[pa.RecordBatch]:
     """
     Convert one or more newline-delimited JSON STAC files to a generator of Arrow
     RecordBatches.

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -23,7 +23,7 @@ import shapely
 import shapely.geometry
 
 from stac_geoparquet.arrow._schema.models import InferredSchema
-from stac_geoparquet.arrow._to_parquet import WGS84_CRS_JSON
+from stac_geoparquet.arrow._crs import WGS84_CRS_JSON
 from stac_geoparquet.arrow._util import stac_items_to_arrow
 
 

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -74,9 +74,27 @@ def parse_stac_items_to_arrow(
 def parse_stac_ndjson_to_arrow(
     path: Union[Union[str, Path], Iterable[Union[str, Path]]],
     *,
-    chunk_size: int = 8192,
+    chunk_size: int = 65536,
     schema: Optional[Union[pa.Schema, InferredSchema]] = None,
 ):
+    """
+    Convert one or more newline-delimited JSON STAC files to a generator of Arrow
+    RecordBatches.
+
+    Each RecordBatch in the returned iterator is guaranteed to have an identical schema,
+    and can be used to write to one or more Parquet files.
+
+    Args:
+        path: One or more paths to files with STAC items.
+        chunk_size: The chunk size. Defaults to 65536.
+        schema: The schema to represent the input STAC data. Defaults to None, in which
+            case the schema will first be inferred via a full pass over the input data.
+            In this case, there will be two full passes over the input data: one to
+            infer a common schema across all data and another to read the data.
+
+    Yields:
+        Arrow RecordBatch with a single chunk of Item data.
+    """
     # Define outside of if/else to make mypy happy
     items: List[dict] = []
 

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -1,10 +1,9 @@
 """Convert STAC data into Arrow tables"""
 
 import json
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union, Generator
+from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, Union
 
 import ciso8601
 import numpy as np
@@ -12,6 +11,9 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import shapely
 import shapely.geometry
+
+from stac_geoparquet.arrow._schema.models import InferredSchema
+from stac_geoparquet.arrow._util import stac_items_to_arrow
 
 
 def _chunks(
@@ -26,8 +28,8 @@ def parse_stac_items_to_arrow(
     items: Sequence[Dict[str, Any]],
     *,
     chunk_size: int = 8192,
-    schema: Optional[pa.Schema] = None,
-    downcast: bool = True,
+    schema: Optional[Union[pa.Schema, InferredSchema]] = None,
+    downcast: bool = False,
 ) -> pa.Table:
     """Parse a collection of STAC Items to a :class:`pyarrow.Table`.
 
@@ -49,11 +51,14 @@ def parse_stac_items_to_arrow(
     """
 
     if schema is not None:
+        if isinstance(schema, InferredSchema):
+            schema = schema.inner
+
         # If schema is provided, then for better memory usage we parse input STAC items
         # to Arrow batches in chunks.
         batches = []
         for chunk in _chunks(items, chunk_size):
-            batches.append(_stac_items_to_arrow(chunk, schema=schema))
+            batches.append(stac_items_to_arrow(chunk, schema=schema))
 
         table = pa.Table.from_batches(batches, schema=schema)
     else:
@@ -61,48 +66,62 @@ def parse_stac_items_to_arrow(
         # else it would be possible for a STAC item late in the collection (after the
         # first chunk) to have a different schema and not match the schema inferred for
         # the first chunk.
-        table = pa.Table.from_batches([_stac_items_to_arrow(items)])
+        table = pa.Table.from_batches([stac_items_to_arrow(items)])
 
     return _process_arrow_table(table, downcast=downcast)
 
 
 def parse_stac_ndjson_to_arrow(
-    path: Union[str, Path],
+    path: Union[Union[str, Path], Iterable[Union[str, Path]]],
     *,
     chunk_size: int = 8192,
-    schema: Optional[pa.Schema] = None,
-    downcast: bool = True,
-) -> pa.Table:
+    schema: Optional[Union[pa.Schema, InferredSchema]] = None,
+):
     # Define outside of if/else to make mypy happy
     items: List[dict] = []
 
     # If the schema was not provided, then we need to load all data into memory at once
     # to perform schema resolution.
     if schema is None:
-        with open(path) as f:
-            for line in f:
-                items.append(json.loads(line))
+        inferred_schema = InferredSchema()
+        inferred_schema.update_from_ndjson(path, chunk_size=chunk_size)
+        return parse_stac_ndjson_to_arrow(
+            path, chunk_size=chunk_size, schema=inferred_schema
+        )
 
-        return parse_stac_items_to_arrow(items, chunk_size=chunk_size, schema=schema)
+    # Check if path is an iterable
+    # If so, recursively call this function on each item in the iterable
+    if not isinstance(path, (str, Path)):
+        for p in path:
+            yield from parse_stac_ndjson_to_arrow(
+                p, chunk_size=chunk_size, schema=schema
+            )
+
+        return
+
+    if isinstance(schema, InferredSchema):
+        schema = schema.inner
 
     # Otherwise, we can stream over the input, converting each batch of `chunk_size`
     # into an Arrow RecordBatch at a time. This is much more memory efficient.
     with open(path) as f:
-        batches: List[pa.RecordBatch] = []
         for line in f:
             items.append(json.loads(line))
 
             if len(items) >= chunk_size:
-                batches.append(_stac_items_to_arrow(items, schema=schema))
+                batch = stac_items_to_arrow(items, schema=schema)
+                yield from _process_arrow_table(
+                    pa.Table.from_batches([batch]), downcast=False
+                ).to_batches()
                 items = []
 
     # Don't forget the last chunk in case the total number of items is not a multiple of
     # chunk_size.
     if len(items) > 0:
-        batches.append(_stac_items_to_arrow(items, schema=schema))
-
-    table = pa.Table.from_batches(batches, schema=schema)
-    return _process_arrow_table(table, downcast=downcast)
+        batch = stac_items_to_arrow(items, schema=schema)
+        yield from _process_arrow_table(
+            pa.Table.from_batches([batch]), downcast=False
+        ).to_batches()
 
 
 def _process_arrow_table(table: pa.Table, *, downcast: bool = True) -> pa.Table:
@@ -110,47 +129,6 @@ def _process_arrow_table(table: pa.Table, *, downcast: bool = True) -> pa.Table:
     table = _convert_timestamp_columns(table)
     table = _convert_bbox_to_struct(table, downcast=downcast)
     return table
-
-
-def _stac_items_to_arrow(
-    items: Sequence[Dict[str, Any]], *, schema: Optional[pa.Schema] = None
-) -> pa.RecordBatch:
-    """Convert dicts representing STAC Items to Arrow
-
-    This converts GeoJSON geometries to WKB before Arrow conversion to allow multiple
-    geometry types.
-
-    All items will be parsed into a single RecordBatch, meaning that each internal array
-    is fully contiguous in memory for the length of `items`.
-
-    Args:
-        items: STAC Items to convert to Arrow
-
-    Kwargs:
-        schema: An optional schema that describes the format of the data. Note that this
-            must represent the geometry column as binary type.
-
-    Returns:
-        Arrow RecordBatch with items in Arrow
-    """
-    # Preprocess GeoJSON to WKB in each STAC item
-    # Otherwise, pyarrow will try to parse coordinates into a native geometry type and
-    # if you have multiple geometry types pyarrow will error with
-    # `ArrowInvalid: cannot mix list and non-list, non-null values`
-    wkb_items = []
-    for item in items:
-        wkb_item = deepcopy(item)
-        # Note: this mutates the existing items. Should we
-        wkb_item["geometry"] = shapely.to_wkb(
-            shapely.geometry.shape(wkb_item["geometry"]), flavor="iso"
-        )
-        wkb_items.append(wkb_item)
-
-    if schema is not None:
-        array = pa.array(wkb_items, type=pa.struct(schema))
-    else:
-        array = pa.array(wkb_items)
-    return pa.RecordBatch.from_struct_array(array)
 
 
 def _bring_properties_to_top_level(table: pa.Table) -> pa.Table:

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -103,9 +103,10 @@ def parse_stac_ndjson_to_arrow(
     if schema is None:
         inferred_schema = InferredSchema()
         inferred_schema.update_from_ndjson(path, chunk_size=chunk_size)
-        return parse_stac_ndjson_to_arrow(
+        yield from parse_stac_ndjson_to_arrow(
             path, chunk_size=chunk_size, schema=inferred_schema
         )
+        return
 
     # Check if path is an iterable
     # If so, recursively call this function on each item in the iterable

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -4,12 +4,10 @@ from typing import Any, Iterable, Optional, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-from pyproj import CRS
 
 from stac_geoparquet.arrow._schema.models import InferredSchema
 from stac_geoparquet.arrow._to_arrow import parse_stac_ndjson_to_arrow
-
-WGS84_CRS_JSON = CRS.from_epsg(4326).to_json_dict()
+from stac_geoparquet.arrow._crs import WGS84_CRS_JSON
 
 
 def parse_stac_ndjson_to_parquet(

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -27,10 +27,10 @@ def parse_stac_ndjson_to_parquet(
         output_path: A path to the output Parquet file.
         chunk_size: The chunk size. Defaults to 65536.
         schema: The schema to represent the input STAC data. Defaults to None, in which
-            case the schema will be inferred via a full pass over the input data. In
-            this case, there will be two full passes over the input data: one to infer a
-            common schema across all data and another to read the data and iteratively
-            convert to GeoParquet.
+            case the schema will first be inferred via a full pass over the input data.
+            In this case, there will be two full passes over the input data: one to
+            infer a common schema across all data and another to read the data and
+            iteratively convert to GeoParquet.
     """
     batches_iter = parse_stac_ndjson_to_arrow(
         input_path, chunk_size=chunk_size, schema=schema

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -18,8 +18,8 @@ def parse_stac_ndjson_to_parquet(
     *,
     chunk_size: int = 65536,
     schema: Optional[Union[pa.Schema, InferredSchema]] = None,
-    **kwargs,
-):
+    **kwargs: Any,
+) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet
 
     Args:
@@ -59,7 +59,7 @@ def to_parquet(table: pa.Table, where: Any, **kwargs: Any) -> None:
     pq.write_table(table, where, **kwargs)
 
 
-def _create_geoparquet_metadata():
+def _create_geoparquet_metadata() -> dict[bytes, bytes]:
     # TODO: include bbox of geometries
     column_meta = {
         "encoding": "WKB",

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -1,11 +1,46 @@
 import json
-from typing import Any
+from pathlib import Path
+from typing import Any, Iterable, Optional, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 from pyproj import CRS
 
+from stac_geoparquet.arrow._schema.models import InferredSchema
+from stac_geoparquet.arrow._to_arrow import parse_stac_ndjson_to_arrow
+
 WGS84_CRS_JSON = CRS.from_epsg(4326).to_json_dict()
+
+
+def parse_stac_ndjson_to_parquet(
+    input_path: Union[Union[str, Path], Iterable[Union[str, Path]]],
+    output_path: Union[str, Path],
+    *,
+    chunk_size: int = 65536,
+    schema: Optional[Union[pa.Schema, InferredSchema]] = None,
+    **kwargs,
+):
+    """Convert one or more newline-delimited JSON STAC files to GeoParquet
+
+    Args:
+        input_path: One or more paths to files with STAC items.
+        output_path: A path to the output Parquet file.
+        chunk_size: The chunk size. Defaults to 65536.
+        schema: The schema to represent the input STAC data. Defaults to None, in which
+            case the schema will be inferred via a full pass over the input data. In
+            this case, there will be two full passes over the input data: one to infer a
+            common schema across all data and another to read the data and iteratively
+            convert to GeoParquet.
+    """
+    batches_iter = parse_stac_ndjson_to_arrow(
+        input_path, chunk_size=chunk_size, schema=schema
+    )
+    first_batch = next(batches_iter)
+    schema = first_batch.schema.with_metadata(_create_geoparquet_metadata())
+    with pq.ParquetWriter(output_path, schema, **kwargs) as writer:
+        writer.write_batch(first_batch)
+        for batch in batches_iter:
+            writer.write_batch(batch)
 
 
 def to_parquet(table: pa.Table, where: Any, **kwargs: Any) -> None:
@@ -17,6 +52,14 @@ def to_parquet(table: pa.Table, where: Any, **kwargs: Any) -> None:
         table: The table to write to Parquet
         where: The destination for saving.
     """
+    metadata = table.schema.metadata or {}
+    metadata.update(_create_geoparquet_metadata())
+    table = table.replace_schema_metadata(metadata)
+
+    pq.write_table(table, where, **kwargs)
+
+
+def _create_geoparquet_metadata():
     # TODO: include bbox of geometries
     column_meta = {
         "encoding": "WKB",
@@ -38,9 +81,4 @@ def to_parquet(table: pa.Table, where: Any, **kwargs: Any) -> None:
         "columns": {"geometry": column_meta},
         "primary_column": "geometry",
     }
-
-    metadata = table.schema.metadata or {}
-    metadata.update({b"geo": json.dumps(geo_meta).encode("utf-8")})
-    table = table.replace_schema_metadata(metadata)
-
-    pq.write_table(table, where, **kwargs)
+    return {b"geo": json.dumps(geo_meta).encode("utf-8")}

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -1,0 +1,62 @@
+from copy import deepcopy
+from typing import Any, Dict, Optional, Sequence
+
+import pyarrow as pa
+import shapely
+import shapely.geometry
+
+
+def stac_items_to_arrow(
+    items: Sequence[Dict[str, Any]], *, schema: Optional[pa.Schema] = None
+) -> pa.RecordBatch:
+    """Convert dicts representing STAC Items to Arrow
+
+    This converts GeoJSON geometries to WKB before Arrow conversion to allow multiple
+    geometry types.
+
+    All items will be parsed into a single RecordBatch, meaning that each internal array
+    is fully contiguous in memory for the length of `items`.
+
+    Args:
+        items: STAC Items to convert to Arrow
+
+    Kwargs:
+        schema: An optional schema that describes the format of the data. Note that this
+            must represent the geometry column as binary type.
+
+    Returns:
+        Arrow RecordBatch with items in Arrow
+    """
+    # Preprocess GeoJSON to WKB in each STAC item
+    # Otherwise, pyarrow will try to parse coordinates into a native geometry type and
+    # if you have multiple geometry types pyarrow will error with
+    # `ArrowInvalid: cannot mix list and non-list, non-null values`
+    wkb_items = []
+    for item in items:
+        wkb_item = deepcopy(item)
+        wkb_item["geometry"] = shapely.to_wkb(
+            shapely.geometry.shape(wkb_item["geometry"]), flavor="iso"
+        )
+
+        # If a proj:geometry key exists in top-level properties, convert that to WKB
+        if "proj:geometry" in wkb_item["properties"]:
+            wkb_item["proj:geometry"] = shapely.to_wkb(
+                shapely.geometry.shape(wkb_item["proj:geometry"]), flavor="iso"
+            )
+
+        # If a proj:geometry key exists in any asset properties, convert that to WKB
+        for asset_value in wkb_item["assets"].values():
+            if "proj:geometry" in asset_value:
+                asset_value["proj:geometry"] = shapely.to_wkb(
+                    shapely.geometry.shape(asset_value["proj:geometry"]),
+                    flavor="iso",
+                )
+
+        wkb_items.append(wkb_item)
+
+    if schema is not None:
+        array = pa.array(wkb_items, type=pa.struct(schema))
+    else:
+        array = pa.array(wkb_items)
+
+    return pa.RecordBatch.from_struct_array(array)

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -41,7 +41,8 @@ def stac_items_to_arrow(
         # If a proj:geometry key exists in top-level properties, convert that to WKB
         if "proj:geometry" in wkb_item["properties"]:
             wkb_item["proj:geometry"] = shapely.to_wkb(
-                shapely.geometry.shape(wkb_item["proj:geometry"]), flavor="iso"
+                shapely.geometry.shape(wkb_item["properties"]["proj:geometry"]),
+                flavor="iso",
             )
 
         # If a proj:geometry key exists in any asset properties, convert that to WKB

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -40,7 +40,7 @@ def stac_items_to_arrow(
 
         # If a proj:geometry key exists in top-level properties, convert that to WKB
         if "proj:geometry" in wkb_item["properties"]:
-            wkb_item["proj:geometry"] = shapely.to_wkb(
+            wkb_item["properties"]["proj:geometry"] = shapely.to_wkb(
                 shapely.geometry.shape(wkb_item["properties"]["proj:geometry"]),
                 flavor="iso",
             )


### PR DESCRIPTION
In some cases, it's desired to handle bulk STAC to GeoParquet conversion in a foolproof way with minimal user input. In #49, I presented an option to handle partial schemas, so the user could define only which STAC extensions they use, but this is still not totally foolproof. In particular, it can fail due to versioning issues, if there are multiple extension versions and/or multiple core versions in a single collection. Additionally, that approach requires more ongoing maintenance to keep the partial schemas up to date as extensions release new versions.

It may still be desired to finish and merge #49, but I think it makes sense to at least include this "exhaustive" inference as an option, because it's the most foolproof approach (though time consuming). In this PR, we implement a full scan over the input data, which infers a single unified Arrow schema before converting _any_ data to Parquet.

I tested this with the horrible data I got stuck with last fall at the STAC Sprint. I had fetched 10,000 STAC Items from AWS's Sentinel 2 STAC collection, which had a variety of versions of STAC and different assets in each item. Though with this horrid input it does create a pretty insane schema... in this case with 52 separate asset keys 😱 , it works without any user input! (The pyarrow text repr of this schema is 90,000 characters, which means it's too big to paste into a comment 😂 )

### Change list 

- Add `InferredSchema` class. This is intended to be used to iteratively build up a schema while scanning input JSON data.
- Update existing functions to allow `InferredSchema` input to the `schema` argument.
- Change the return type of `parse_stac_ndjson_to_arrow` to return a Generator of arrow RecordBatches.
- Allow `parse_stac_ndjson_to_arrow` to take in one or more paths to newline-delimited JSON files.
- Add top-level `parse_stac_ndjson_to_parquet` which wraps `parse_stac_ndjson_to_arrow` to construct a single GeoParquet file from input ndjson data. This _streams_ data, and so does not hold all input data in memory at once. In the case where the user does not pass in a schema, it first scans the entire input to infer a unified schema, then creates the record batch generator.
- Fix Arrow -> STAC conversion for nested GeoJSON properties. We were already converting GeoJSON to WKB at the top level, which is necessary in case there are Polygon and MultiPolygon geometries in the same collection. But we hadn't been doing that for the nested `proj:geometry` key, which is also a GeoJSON, and which should also be WKB for the same reasons. This fixes that for both conversion to arrow and from arrow back to JSON.

