### PR TITLE
Update spec to document storing all GeoJSON properties as WKB

### DIFF
--- a/spec/stac-geoparquet-spec.md
+++ b/spec/stac-geoparquet-spec.md
@@ -36,6 +36,7 @@ most of the fields should be the same in STAC and in GeoParquet.
 * STAC GeoParquet does not support properties that are named such that they collide with a top-level key.
 * datetime columns should be stored as a [native timestamp][timestamp], not as a string
 * The Collection JSON should be included in the Parquet metadata. See [Collection JSON](#collection-json) below.
+* Any other properties that would be stored as GeoJSON in a STAC JSON Item (e.g. `proj:geometry`) should be stored as a binary column with WKB encoding. This simplifies the handling of collections with multiple geometry types.
 
 ### Link Struct
 


### PR DESCRIPTION
Some extensions also store GeoJSON geometries. I'm primarily thinking of `proj:geometry`, but maybe there are others?

This updates the spec to recommend all GeoJSON geometries be stored as WKB. It's not uncommon for a STAC Collection that mostly holds Polygon geometries to occasionally have some MultiPolygon geometries, for example over the international date line. It's much easier to handle these edge cases when all geometries are stored as WKB.