### PR TITLE
Include GeoArrow metadata on constructed Arrow table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "packaging",
     "pandas",
     "pyarrow",
+    "pyproj",
     "pystac",
     "shapely",
 ]

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -210,6 +210,20 @@ def test_round_trip(collection_id: str):
         assert_json_value_equal(result, expected, precision=0)
 
 
+def test_table_contains_geoarrow_metadata():
+    collection_id = "naip"
+    with open(HERE / "data" / f"{collection_id}-pc.json") as f:
+        items = json.load(f)
+
+    table = parse_stac_items_to_arrow(items)
+    field_meta = table.schema.field("geometry").metadata
+    assert field_meta[b"ARROW:extension:name"] == b"geoarrow.wkb"
+    assert json.loads(field_meta[b"ARROW:extension:metadata"])["crs"]["id"] == {
+        "authority": "EPSG",
+        "code": 4326,
+    }
+
+
 def test_to_arrow_deprecated():
     with pytest.warns(FutureWarning):
         import stac_geoparquet.to_arrow


### PR DESCRIPTION
### Change list

- Include `geoarrow.wkb` on the Arrow field metadata to declare that the `geometry` binary column is WKB-encoded and in WGS84 CRS.

This means that the data produced by stac-geoparquet is interoperable with other Arrow-based geospatial tools, for example, [Lonboard](https://github.com/developmentseed/lonboard):

```py
import lonboard
from stac_geoparquet.arrow import parse_stac_items_to_arrow

with open(HERE / "data" / f"naip-pc.json") as f:
    items = json.load(f)

table = parse_stac_items_to_arrow(items)
lonboard.viz(table)
```

<img width="544" alt="image" src="https://github.com/stac-utils/stac-geoparquet/assets/15164633/4f2504f7-88db-4ed5-9ca0-11e695e04c71">

cc @bitner