### PR TITLE
User iterables / and record batches in to_arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Note that `stac_geoparquet` lifts the keys in the item `properties` up to the to
 >>> import requests
 >>> import stac_geoparquet.arrow
 >>> import pyarrow.parquet
+>>> import pyarrow as pa
 
 >>> items = requests.get(
 ...     "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items"
 ... ).json()["features"]
->>> table = stac_geoparquet.arrow.parse_stac_items_to_arrow(items)
+>>> table = pa.Table.from_batches(stac_geoparquet.arrow.parse_stac_items_to_arrow(items))
 >>> stac_geoparquet.arrow.to_parquet(table, "items.parquet")
 >>> table2 = pyarrow.parquet.read_table("items.parquet")
 >>> items2 = list(stac_geoparquet.arrow.stac_table_to_items(table2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pyproj",
     "pystac",
     "shapely",
+    "orjson",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "geopandas",
     "packaging",
     "pandas",
-    "pyarrow",
+    # Needed for RecordBatch.append_column
+    "pyarrow>=16",
     "pyproj",
     "pystac",
     "shapely",

--- a/stac_geoparquet/arrow/_from_arrow.py
+++ b/stac_geoparquet/arrow/_from_arrow.py
@@ -133,7 +133,7 @@ def _lower_properties_from_top_level(batch: pa.RecordBatch) -> pa.RecordBatch:
         properties_column_fields.append(batch.schema.field(column_idx))
 
     struct_arr = pa.StructArray.from_arrays(
-        batch.columns, fields=properties_column_fields
+        batch.select(properties_column_names).columns, fields=properties_column_fields
     )
 
     return batch.drop_columns(properties_column_names).append_column(

--- a/stac_geoparquet/arrow/_schema/models.py
+++ b/stac_geoparquet/arrow/_schema/models.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Iterable, Sequence, Union
+from typing import Any, Dict, Iterable, Optional, Sequence, Union
 
 import pyarrow as pa
 
@@ -30,6 +30,7 @@ class InferredSchema:
         path: Union[str, Path, Iterable[Union[str, Path]]],
         *,
         chunk_size: int = 65536,
+        limit: Optional[int] = None,
     ) -> None:
         """
         Update this inferred schema from one or more newline-delimited JSON STAC files.
@@ -37,8 +38,11 @@ class InferredSchema:
         Args:
             path: One or more paths to files with STAC items.
             chunk_size: The chunk size to load into memory at a time. Defaults to 65536.
+
+        Other args:
+            limit: The maximum number of JSON Items to use for schema inference
         """
-        for batch in read_json_chunked(path, chunk_size=chunk_size):
+        for batch in read_json_chunked(path, chunk_size=chunk_size, limit=limit):
             self.update_from_items(batch)
 
     def update_from_items(self, items: Sequence[Dict[str, Any]]) -> None:

--- a/stac_geoparquet/arrow/_schema/models.py
+++ b/stac_geoparquet/arrow/_schema/models.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from typing import Any, Dict, Iterable, Sequence, Union
+
+import pyarrow as pa
+
+from stac_geoparquet.arrow._util import stac_items_to_arrow
+from stac_geoparquet.json_reader import read_json
+
+
+class InferredSchema:
+    """
+    A schema representing the original STAC JSON with absolutely minimal modifications.
+
+    The only modification from the data is converting any geometry fields from GeoJSON
+    to WKB.
+    """
+
+    inner: pa.Schema
+    """The underlying Arrow schema."""
+
+    count: int
+    """The total number of items scanned."""
+
+    def __init__(self) -> None:
+        self.inner = pa.schema([])
+        self.count = 0
+
+    def update_from_json(
+        self,
+        path: Union[str, Path, Iterable[Union[str, Path]]],
+        *,
+        chunk_size: int = 65536,
+    ) -> None:
+        """
+        Update this inferred schema from one or more newline-delimited JSON STAC files.
+
+        Args:
+            path: One or more paths to files with STAC items.
+            chunk_size: The chunk size to load into memory at a time. Defaults to 65536.
+        """
+        items = []
+        for item in read_json(path):
+            items.append(item)
+
+            if len(items) >= chunk_size:
+                self.update_from_items(items)
+                items = []
+
+        # Handle remainder
+        if len(items) > 0:
+            self.update_from_items(items)
+
+    def update_from_items(self, items: Sequence[Dict[str, Any]]) -> None:
+        """Update this inferred schema from a sequence of STAC Items."""
+        self.count += len(items)
+        current_schema = stac_items_to_arrow(items, schema=None).schema
+        new_schema = pa.unify_schemas(
+            [self.inner, current_schema], promote_options="permissive"
+        )
+        self.inner = new_schema

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -44,7 +44,7 @@ def parse_stac_items_to_batches(
         an iterable of pyarrow RecordBatches with the STAC-GeoParquet representation of items.
     """
     for item_batch in batched_iter(items, chunk_size):
-        yield stac_items_to_arrow(item_batch)
+        yield stac_items_to_arrow(item_batch, schema=schema)
 
 
 def parse_stac_items_to_arrow(

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -62,6 +62,7 @@ def parse_stac_ndjson_to_arrow(
     *,
     chunk_size: int = 65536,
     schema: Optional[pa.Schema] = None,
+    limit: Optional[int] = None,
 ) -> Iterator[pa.RecordBatch]:
     """
     Convert one or more newline-delimited JSON STAC files to a generator of Arrow
@@ -78,6 +79,9 @@ def parse_stac_ndjson_to_arrow(
             In this case, there will be two full passes over the input data: one to
             infer a common schema across all data and another to read the data.
 
+    Other args:
+        limit: The maximum number of JSON Items to use for schema inference
+
     Yields:
         Arrow RecordBatch with a single chunk of Item data.
     """
@@ -85,7 +89,7 @@ def parse_stac_ndjson_to_arrow(
     # to perform schema resolution.
     if schema is None:
         inferred_schema = InferredSchema()
-        inferred_schema.update_from_json(path, chunk_size=chunk_size)
+        inferred_schema.update_from_json(path, chunk_size=chunk_size, limit=limit)
         yield from parse_stac_ndjson_to_arrow(
             path, chunk_size=chunk_size, schema=inferred_schema
         )

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -17,7 +17,6 @@ def parse_stac_ndjson_to_parquet(
     *,
     chunk_size: int = 65536,
     schema: Optional[pa.Schema] = None,
-    downcast: bool = True,
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet
@@ -33,7 +32,7 @@ def parse_stac_ndjson_to_parquet(
             iteratively convert to GeoParquet.
     """
     batches = parse_stac_items_to_batches(
-        read_json(input_path), chunk_size=chunk_size, schema=schema, downcast=downcast
+        read_json(input_path), chunk_size=chunk_size, schema=schema
     )
     if schema is None:
         unified_batches = []

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable, Optional, Union
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from stac_geoparquet.arrow._schema.models import InferredSchema
 from stac_geoparquet.arrow._to_arrow import parse_stac_items_to_batches
 from stac_geoparquet.json_reader import read_json
 from stac_geoparquet.arrow._util import update_batch_schema
@@ -12,11 +13,11 @@ from stac_geoparquet.arrow._crs import WGS84_CRS_JSON
 
 
 def parse_stac_ndjson_to_parquet(
-    input_path: Union[Union[str, Path], Iterable[Union[str, Path]]],
+    input_path: Union[str, Path, Iterable[Union[str, Path]]],
     output_path: Union[str, Path],
     *,
     chunk_size: int = 65536,
-    schema: Optional[pa.Schema] = None,
+    schema: Optional[Union[pa.Schema, InferredSchema]] = None,
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -39,9 +39,7 @@ def batched_iter(
 
 
 def stac_items_to_arrow(
-    items: Iterable[Dict[str, Any]],
-    *,
-    schema: Optional[pa.Schema] = None,
+    items: Iterable[Dict[str, Any]], *, schema: Optional[pa.Schema] = None
 ) -> pa.RecordBatch:
     """Convert dicts representing STAC Items to Arrow
 
@@ -93,6 +91,7 @@ def stac_items_to_arrow(
         array = pa.array(wkb_items, type=pa.struct(schema))
     else:
         array = pa.array(wkb_items)
+
     return _process_arrow_batch(pa.RecordBatch.from_struct_array(array))
 
 

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -28,14 +28,18 @@ def update_batch_schema(
 
 
 def batched_iter(
-    lst: Iterable[Dict[str, Any]], n: int
+    lst: Iterable[Dict[str, Any]], n: int, *, limit: Optional[int] = None
 ) -> Iterable[Sequence[Dict[str, Any]]]:
     """Yield successive n-sized chunks from iterable."""
     if n < 1:
         raise ValueError("n must be at least one")
     it = iter(lst)
+    count = 0
     while batch := tuple(islice(it, n)):
         yield batch
+        count += len(batch)
+        if limit and count >= limit:
+            return
 
 
 def stac_items_to_arrow(

--- a/stac_geoparquet/json_reader.py
+++ b/stac_geoparquet/json_reader.py
@@ -1,13 +1,16 @@
 """Return an iterator of items from an ndjson, a json array of items, or a featurecollection of items."""
 
-import orjson
-from typing import Iterator, Dict, Any, Union, Iterable
 from pathlib import Path
+from typing import Any, Dict, Iterable, Sequence, Union
+
+import orjson
+
+from stac_geoparquet.arrow._util import batched_iter
 
 
 def read_json(
     path: Union[str, Path, Iterable[Union[str, Path]]],
-) -> Iterator[Dict[str, Any]]:
+) -> Iterable[Dict[str, Any]]:
     """Read a json or ndjson file."""
     if isinstance(path, (str, Path)):
         path = [path]
@@ -33,3 +36,10 @@ def read_json(
                     yield from json
                 else:
                     yield from json["features"]
+
+
+def read_json_chunked(
+    path: Union[str, Path, Iterable[Union[str, Path]]], chunk_size: int
+) -> Iterable[Sequence[Dict[str, Any]]]:
+    """Read from a JSON or NDJSON file in chunks of `chunk_size`."""
+    return batched_iter(read_json(path), chunk_size)

--- a/stac_geoparquet/json_reader.py
+++ b/stac_geoparquet/json_reader.py
@@ -1,7 +1,7 @@
 """Return an iterator of items from an ndjson, a json array of items, or a featurecollection of items."""
 
 from pathlib import Path
-from typing import Any, Dict, Iterable, Sequence, Union
+from typing import Any, Dict, Iterable, Optional, Sequence, Union
 
 import orjson
 
@@ -39,7 +39,10 @@ def read_json(
 
 
 def read_json_chunked(
-    path: Union[str, Path, Iterable[Union[str, Path]]], chunk_size: int
+    path: Union[str, Path, Iterable[Union[str, Path]]],
+    chunk_size: int,
+    *,
+    limit: Optional[int] = None,
 ) -> Iterable[Sequence[Dict[str, Any]]]:
     """Read from a JSON or NDJSON file in chunks of `chunk_size`."""
-    return batched_iter(read_json(path), chunk_size)
+    return batched_iter(read_json(path), chunk_size, limit=limit)

--- a/stac_geoparquet/json_reader.py
+++ b/stac_geoparquet/json_reader.py
@@ -1,0 +1,22 @@
+"""Return an iterator of items from an ndjson, a json array of items, or a featurecollection of items."""
+
+import orjson
+from typing import Iterator, Dict, Any, Union
+from pathlib import Path
+
+
+def read_json(path: Union[str, Path]) -> Iterator[Dict[str, Any]]:
+    """Read a json or ndjson file."""
+    with open(path) as f:
+        try:
+            # read ndjson
+            for line in f:
+                yield orjson.loads(line.strip())
+        except orjson.JSONDecodeError:
+            f.seek(0)
+            # read full json file as either a list or FeatureCollection
+            json = orjson.loads(f.read())
+            if isinstance(json, list):
+                yield from json
+            else:
+                yield from json["features"]

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -3,6 +3,7 @@ import math
 from pathlib import Path
 from typing import Any, Dict, Sequence, Union
 
+import pyarrow as pa
 import pytest
 from ciso8601 import parse_rfc3339
 
@@ -197,7 +198,7 @@ def test_round_trip(collection_id: str):
     with open(HERE / "data" / f"{collection_id}-pc.json") as f:
         items = json.load(f)
 
-    table = parse_stac_items_to_arrow(items)
+    table = pa.Table.from_batches(parse_stac_items_to_arrow(items))
     items_result = list(stac_table_to_items(table))
 
     for result, expected in zip(items_result, items):
@@ -209,7 +210,7 @@ def test_table_contains_geoarrow_metadata():
     with open(HERE / "data" / f"{collection_id}-pc.json") as f:
         items = json.load(f)
 
-    table = parse_stac_items_to_arrow(items)
+    table = pa.Table.from_batches(parse_stac_items_to_arrow(items))
     field_meta = table.schema.field("geometry").metadata
     assert field_meta[b"ARROW:extension:name"] == b"geoarrow.wkb"
     assert json.loads(field_meta[b"ARROW:extension:metadata"])["crs"]["id"] == {

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -197,13 +197,7 @@ def test_round_trip(collection_id: str):
     with open(HERE / "data" / f"{collection_id}-pc.json") as f:
         items = json.load(f)
 
-    table = parse_stac_items_to_arrow(items, downcast=True)
-    items_result = list(stac_table_to_items(table))
-
-    for result, expected in zip(items_result, items):
-        assert_json_value_equal(result, expected, precision=0.001)
-
-    table = parse_stac_items_to_arrow(items, downcast=False)
+    table = parse_stac_items_to_arrow(items)
     items_result = list(stac_table_to_items(table))
 
     for result, expected in zip(items_result, items):


### PR DESCRIPTION
- User orjson rather than json for speed.
- Allow items to be passed in as an iterable
- Use RecordBatches for processing
  - Since we are processing on record batches, don't use chunked arrays
- Add function for reading json that can read either ndjson or items in a json file either as a root list or FeatureCollection