### PR TITLE
Include `proj:geometry` column in GeoParquet metadata when writing

### DIFF
--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -35,7 +35,9 @@ def parse_stac_ndjson_to_parquet(
         input_path, chunk_size=chunk_size, schema=schema
     )
     first_batch = next(batches_iter)
-    schema = first_batch.schema.with_metadata(_create_geoparquet_metadata())
+    schema = first_batch.schema.with_metadata(
+        _create_geoparquet_metadata(pa.Table.from_batches([first_batch]))
+    )
     with pq.ParquetWriter(output_path, schema, **kwargs) as writer:
         writer.write_batch(first_batch)
         for batch in batches_iter:

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -77,7 +77,7 @@ def _create_geoparquet_metadata(table: pa.Table) -> dict[bytes, bytes]:
             }
         },
     }
-    geo_meta = {
+    geo_meta: Dict[str, Any] = {
         "version": "1.1.0-dev",
         "columns": {"geometry": column_meta},
         "primary_column": "geometry",


### PR DESCRIPTION
Include `proj:geometry` column as a secondary geometry column in the `geo` metadata.

Ref https://github.com/stac-utils/stac-geoparquet/pull/51#issuecomment-2133727531

This sets the CRS of that column to `null`, which means it is explicitly unknown. Ref https://github.com/opengeospatial/geoparquet/pull/225