### PR TITLE
Allow writing either GeoParquet 1.0 or GeoParquet 1.1 schema metadata

### DIFF
--- a/stac_geoparquet/arrow/__init__.py
+++ b/stac_geoparquet/arrow/__init__.py
@@ -4,4 +4,9 @@ from ._api import (
     stac_table_to_items,
     stac_table_to_ndjson,
 )
+from ._constants import (
+    DEFAULT_JSON_CHUNK_SIZE,
+    DEFAULT_PARQUET_SCHEMA_VERSION,
+    SUPPORTED_PARQUET_SCHEMA_VERSIONS,
+)
 from ._to_parquet import parse_stac_ndjson_to_parquet, to_parquet

--- a/stac_geoparquet/arrow/_api.py
+++ b/stac_geoparquet/arrow/_api.py
@@ -74,7 +74,7 @@ def parse_stac_ndjson_to_arrow(
             In this case, there will be two full passes over the input data: one to
             infer a common schema across all data and another to read the data.
 
-    Other args:
+    Keyword Args:
         limit: The maximum number of JSON Items to use for schema inference
 
     Yields:

--- a/stac_geoparquet/arrow/_api.py
+++ b/stac_geoparquet/arrow/_api.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, Iterator
 import pyarrow as pa
 
 from stac_geoparquet.arrow._batch import StacArrowBatch, StacJsonBatch
+from stac_geoparquet.arrow._constants import DEFAULT_JSON_CHUNK_SIZE
 from stac_geoparquet.arrow._schema.models import InferredSchema
 from stac_geoparquet.arrow._util import batched_iter
 from stac_geoparquet.json_reader import read_json_chunked
@@ -55,7 +56,7 @@ def parse_stac_items_to_arrow(
 def parse_stac_ndjson_to_arrow(
     path: str | Path | Iterable[str | Path],
     *,
-    chunk_size: int = 65536,
+    chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
     schema: pa.Schema | None = None,
     limit: int | None = None,
 ) -> Iterator[pa.RecordBatch]:

--- a/stac_geoparquet/arrow/_constants.py
+++ b/stac_geoparquet/arrow/_constants.py
@@ -6,5 +6,5 @@ DEFAULT_JSON_CHUNK_SIZE = 65536
 SUPPORTED_PARQUET_SCHEMA_VERSIONS = Literal["1.0.0", "1.1.0"]
 """A Literal type with the supported GeoParquet schema versions."""
 
-DEFAULT_PARQUET_SCHEMA_VERSION = "1.1.0"
+DEFAULT_PARQUET_SCHEMA_VERSION: Literal["1.0.0", "1.1.0"] = "1.1.0"
 """The default GeoParquet schema version written to file."""

--- a/stac_geoparquet/arrow/_constants.py
+++ b/stac_geoparquet/arrow/_constants.py
@@ -1,0 +1,10 @@
+from typing import Literal
+
+DEFAULT_JSON_CHUNK_SIZE = 65536
+"""The default chunk size to use for reading JSON into memory."""
+
+SUPPORTED_PARQUET_SCHEMA_VERSIONS = Literal["1.0.0", "1.1.0"]
+"""A Literal type with the supported GeoParquet schema versions."""
+
+DEFAULT_PARQUET_SCHEMA_VERSION = "1.1.0"
+"""The default GeoParquet schema version written to file."""

--- a/stac_geoparquet/arrow/_constants.py
+++ b/stac_geoparquet/arrow/_constants.py
@@ -6,5 +6,5 @@ DEFAULT_JSON_CHUNK_SIZE = 65536
 SUPPORTED_PARQUET_SCHEMA_VERSIONS = Literal["1.0.0", "1.1.0"]
 """A Literal type with the supported GeoParquet schema versions."""
 
-DEFAULT_PARQUET_SCHEMA_VERSION: Literal["1.0.0", "1.1.0"] = "1.1.0"
+DEFAULT_PARQUET_SCHEMA_VERSION: SUPPORTED_PARQUET_SCHEMA_VERSIONS = "1.1.0"
 """The default GeoParquet schema version written to file."""

--- a/stac_geoparquet/arrow/_delta_lake.py
+++ b/stac_geoparquet/arrow/_delta_lake.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, Literal
 
 import pyarrow as pa
 from deltalake import write_deltalake
@@ -21,14 +21,35 @@ def parse_stac_ndjson_to_delta_lake(
     chunk_size: int = 65536,
     schema: pa.Schema | None = None,
     limit: int | None = None,
+    schema_version: Literal["1.0.0", "1.1.0"] = "1.0.0",
     **kwargs: Any,
 ) -> None:
+    """Convert one or more newline-delimited JSON STAC files to Delta Lake
+
+    Args:
+        input_path: One or more paths to files with STAC items.
+        table_or_uri: A path to the output Delta Lake table
+
+    Args:
+        chunk_size: The chunk size to use for reading JSON into memory. Defaults to
+            65536.
+        schema: The schema to represent the input STAC data. Defaults to None, in which
+            case the schema will first be inferred via a full pass over the input data.
+            In this case, there will be two full passes over the input data: one to
+            infer a common schema across all data and another to read the data and
+            iteratively convert to GeoParquet.
+        limit: The maximum number of JSON records to convert.
+        schema_version: GeoParquet specification version; if not provided will default
+            to latest supported version.
+    """
     batches_iter = parse_stac_ndjson_to_arrow(
         input_path, chunk_size=chunk_size, schema=schema, limit=limit
     )
     first_batch = next(batches_iter)
     schema = first_batch.schema.with_metadata(
-        create_geoparquet_metadata(pa.Table.from_batches([first_batch]))
+        create_geoparquet_metadata(
+            pa.Table.from_batches([first_batch]), schema_version=schema_version
+        )
     )
     combined_iter = itertools.chain([first_batch], batches_iter)
     write_deltalake(table_or_uri, combined_iter, schema=schema, engine="rust", **kwargs)

--- a/stac_geoparquet/arrow/_delta_lake.py
+++ b/stac_geoparquet/arrow/_delta_lake.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import itertools
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Literal
+from typing import TYPE_CHECKING, Any, Iterable
 
 import pyarrow as pa
 from deltalake import write_deltalake
 
 from stac_geoparquet.arrow._api import parse_stac_ndjson_to_arrow
-from stac_geoparquet.arrow._to_parquet import create_geoparquet_metadata
+from stac_geoparquet.arrow._constants import DEFAULT_JSON_CHUNK_SIZE
+from stac_geoparquet.arrow._to_parquet import (
+    DEFAULT_PARQUET_SCHEMA_VERSION,
+    SUPPORTED_PARQUET_SCHEMA_VERSIONS,
+    create_geoparquet_metadata,
+)
 
 if TYPE_CHECKING:
     from deltalake import DeltaTable
@@ -18,10 +23,10 @@ def parse_stac_ndjson_to_delta_lake(
     input_path: str | Path | Iterable[str | Path],
     table_or_uri: str | Path | DeltaTable,
     *,
-    chunk_size: int = 65536,
+    chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
     schema: pa.Schema | None = None,
     limit: int | None = None,
-    schema_version: Literal["1.0.0", "1.1.0"] = "1.0.0",
+    schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to Delta Lake

--- a/stac_geoparquet/arrow/_schema/models.py
+++ b/stac_geoparquet/arrow/_schema/models.py
@@ -6,6 +6,7 @@ from typing import Any, Iterable, Sequence
 import pyarrow as pa
 
 from stac_geoparquet.arrow._batch import StacJsonBatch
+from stac_geoparquet.arrow._constants import DEFAULT_JSON_CHUNK_SIZE
 from stac_geoparquet.json_reader import read_json_chunked
 
 
@@ -31,7 +32,7 @@ class InferredSchema:
         self,
         path: str | Path | Iterable[str | Path],
         *,
-        chunk_size: int = 65536,
+        chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
         limit: int | None = None,
     ) -> None:
         """

--- a/stac_geoparquet/arrow/_schema/models.py
+++ b/stac_geoparquet/arrow/_schema/models.py
@@ -41,7 +41,7 @@ class InferredSchema:
             path: One or more paths to files with STAC items.
             chunk_size: The chunk size to load into memory at a time. Defaults to 65536.
 
-        Other args:
+        Keyword Args:
             limit: The maximum number of JSON Items to use for schema inference
         """
         for batch in read_json_chunked(path, chunk_size=chunk_size, limit=limit):

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -100,7 +100,7 @@ def create_geoparquet_metadata(
         "edges": "planar",
     }
 
-    if int(schema_version.split(".")[1]) >= 1:
+    if schema_version_has_bbox_mapping(schema_version):
         column_meta["covering"] = {
             "bbox": {
                 "xmin": ["bbox", "xmin"],
@@ -131,3 +131,11 @@ def create_geoparquet_metadata(
         }
 
     return {b"geo": json.dumps(geo_meta).encode("utf-8")}
+
+
+def schema_version_has_bbox_mapping(schema_version: str) -> bool:
+    """
+    Return true if this GeoParquet schema version supports bounding box covering
+    metadata.
+    """
+    return int(schema_version.split(".")[1]) >= 1

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -133,7 +133,9 @@ def create_geoparquet_metadata(
     return {b"geo": json.dumps(geo_meta).encode("utf-8")}
 
 
-def schema_version_has_bbox_mapping(schema_version: str) -> bool:
+def schema_version_has_bbox_mapping(
+    schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS,
+) -> bool:
     """
     Return true if this GeoParquet schema version supports bounding box covering
     metadata.

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -28,7 +28,7 @@ def parse_stac_ndjson_to_parquet(
         input_path: One or more paths to files with STAC items.
         output_path: A path to the output Parquet file.
 
-    Other args:
+    Keyword Args:
         chunk_size: The chunk size. Defaults to 65536.
         schema: The schema to represent the input STAC data. Defaults to None, in which
             case the schema will first be inferred via a full pass over the input data.
@@ -70,7 +70,7 @@ def to_parquet(
         table: The table to write to Parquet
         where: The destination for saving.
 
-    Other args:
+    Keyword Args:
         schema_version: GeoParquet specification version; if not provided will default
             to latest supported version.
     """

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Iterable, Literal
+from typing import Any, Iterable
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from stac_geoparquet.arrow._api import parse_stac_ndjson_to_arrow
+from stac_geoparquet.arrow._constants import (
+    DEFAULT_JSON_CHUNK_SIZE,
+    DEFAULT_PARQUET_SCHEMA_VERSION,
+    SUPPORTED_PARQUET_SCHEMA_VERSIONS,
+)
 from stac_geoparquet.arrow._crs import WGS84_CRS_JSON
 from stac_geoparquet.arrow._schema.models import InferredSchema
 
@@ -16,10 +21,10 @@ def parse_stac_ndjson_to_parquet(
     input_path: str | Path | Iterable[str | Path],
     output_path: str | Path,
     *,
-    chunk_size: int = 65536,
+    chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
     schema: pa.Schema | InferredSchema | None = None,
     limit: int | None = None,
-    schema_version: Literal["1.0.0", "1.1.0"] = "1.0.0",
+    schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet
@@ -59,7 +64,7 @@ def to_parquet(
     table: pa.Table,
     where: Any,
     *,
-    schema_version: Literal["1.0.0", "1.1.0"] = "1.0.0",
+    schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     **kwargs: Any,
 ) -> None:
     """Write an Arrow table with STAC data to GeoParquet
@@ -84,7 +89,7 @@ def to_parquet(
 def create_geoparquet_metadata(
     table: pa.Table,
     *,
-    schema_version: Literal["1.0.0", "1.1.0"],
+    schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS,
 ) -> dict[bytes, bytes]:
     # TODO: include bbox of geometries
     column_meta = {

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Literal
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -19,6 +19,7 @@ def parse_stac_ndjson_to_parquet(
     chunk_size: int = 65536,
     schema: pa.Schema | InferredSchema | None = None,
     limit: int | None = None,
+    schema_version: Literal["1.0.0", "1.1.0"] = "1.0.0",
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet
@@ -26,12 +27,17 @@ def parse_stac_ndjson_to_parquet(
     Args:
         input_path: One or more paths to files with STAC items.
         output_path: A path to the output Parquet file.
+
+    Other args:
         chunk_size: The chunk size. Defaults to 65536.
         schema: The schema to represent the input STAC data. Defaults to None, in which
             case the schema will first be inferred via a full pass over the input data.
             In this case, there will be two full passes over the input data: one to
             infer a common schema across all data and another to read the data and
             iteratively convert to GeoParquet.
+        limit: The maximum number of JSON records to convert.
+        schema_version: GeoParquet specification version; if not provided will default
+            to latest supported version.
     """
 
     batches_iter = parse_stac_ndjson_to_arrow(
@@ -39,7 +45,9 @@ def parse_stac_ndjson_to_parquet(
     )
     first_batch = next(batches_iter)
     schema = first_batch.schema.with_metadata(
-        create_geoparquet_metadata(pa.Table.from_batches([first_batch]))
+        create_geoparquet_metadata(
+            pa.Table.from_batches([first_batch]), schema_version=schema_version
+        )
     )
     with pq.ParquetWriter(output_path, schema, **kwargs) as writer:
         writer.write_batch(first_batch)
@@ -47,7 +55,13 @@ def parse_stac_ndjson_to_parquet(
             writer.write_batch(batch)
 
 
-def to_parquet(table: pa.Table, where: Any, **kwargs: Any) -> None:
+def to_parquet(
+    table: pa.Table,
+    where: Any,
+    *,
+    schema_version: Literal["1.0.0", "1.1.0"] = "1.0.0",
+    **kwargs: Any,
+) -> None:
     """Write an Arrow table with STAC data to GeoParquet
 
     This writes metadata compliant with GeoParquet 1.1.
@@ -55,15 +69,23 @@ def to_parquet(table: pa.Table, where: Any, **kwargs: Any) -> None:
     Args:
         table: The table to write to Parquet
         where: The destination for saving.
+
+    Other args:
+        schema_version: GeoParquet specification version; if not provided will default
+            to latest supported version.
     """
     metadata = table.schema.metadata or {}
-    metadata.update(create_geoparquet_metadata(table))
+    metadata.update(create_geoparquet_metadata(table, schema_version=schema_version))
     table = table.replace_schema_metadata(metadata)
 
     pq.write_table(table, where, **kwargs)
 
 
-def create_geoparquet_metadata(table: pa.Table) -> dict[bytes, bytes]:
+def create_geoparquet_metadata(
+    table: pa.Table,
+    *,
+    schema_version: Literal["1.0.0", "1.1.0"],
+) -> dict[bytes, bytes]:
     # TODO: include bbox of geometries
     column_meta = {
         "encoding": "WKB",
@@ -71,17 +93,20 @@ def create_geoparquet_metadata(table: pa.Table) -> dict[bytes, bytes]:
         "geometry_types": [],
         "crs": WGS84_CRS_JSON,
         "edges": "planar",
-        "covering": {
+    }
+
+    if int(schema_version.split(".")[1]) >= 1:
+        column_meta["covering"] = {
             "bbox": {
                 "xmin": ["bbox", "xmin"],
                 "ymin": ["bbox", "ymin"],
                 "xmax": ["bbox", "xmax"],
                 "ymax": ["bbox", "ymax"],
             }
-        },
-    }
+        }
+
     geo_meta: dict[str, Any] = {
-        "version": "1.1.0-dev",
+        "version": schema_version,
         "columns": {"geometry": column_meta},
         "primary_column": "geometry",
     }


### PR DESCRIPTION
Adds a `schema_version` argument that decides whether or not GeoParquet 1.1-specific metadata should be included in the written file.

Note that the exact keyword arg `schema_version` was chosen to match the parameter name in GeoPandas' [`to_parquet`](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_parquet.html).

Fixes https://github.com/stac-utils/stac-geoparquet/issues/60

cc @gadomski 