### PR TITLE
Use numpy v2 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,21 +33,22 @@ version-file = "stac_geoparquet/_version.py"
 [project.optional-dependencies]
 pgstac = [
     "fsspec",
-    "pypgstac",
     "psycopg[binary,pool]",
-    "tqdm",
+    "pypgstac",
     "python-dateutil",
+    "tqdm",
 ]
 pc = ["adlfs", "pypgstac", "psycopg[binary,pool]", "tqdm", "azure-data-tables"]
 test = [
+    "mypy",
+    "numpy>=2",
+    "pre-commit",
     "pytest",
     "requests",
-    "pre-commit",
-    "stac-geoparquet[pgstac]",
     "stac-geoparquet[pc]",
+    "stac-geoparquet[pgstac]",
     "types-python-dateutil",
     "types-requests",
-    "mypy",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pgstac = [
     "python-dateutil",
     "tqdm",
 ]
-pc = ["adlfs", "pypgstac", "psycopg[binary,pool]", "tqdm", "azure-data-tables"]
+pc = ["adlfs", "azure-data-tables", "psycopg[binary,pool]", "pypgstac", "tqdm"]
 test = [
     "mypy",
     "numpy>=2",


### PR DESCRIPTION
### Change list

- Set `numpy>=2` in test dependencies
- alphabetize list of dev dependencies

Ref https://github.com/stac-utils/stac-geoparquet/issues/63