### PR TITLE
Require typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pystac",
     "shapely",
     "orjson",
+    "typing_extensions",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pystac",
     "shapely",
     "orjson",
-    "typing_extensions",
+    'typing_extensions; python_version < "3.11"',
 ]
 
 [tool.hatch.version]

--- a/stac_geoparquet/arrow/_batch.py
+++ b/stac_geoparquet/arrow/_batch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Iterable
@@ -12,7 +13,6 @@ import pyarrow.compute as pc
 import shapely
 import shapely.geometry
 from numpy.typing import NDArray
-from typing_extensions import Self
 
 from stac_geoparquet.arrow._from_arrow import (
     convert_bbox_to_array,
@@ -26,6 +26,11 @@ from stac_geoparquet.arrow._to_arrow import (
     convert_timestamp_columns,
 )
 from stac_geoparquet.arrow._util import convert_tuples_to_lists, set_by_path
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class StacJsonBatch:


### PR DESCRIPTION
`typing_extensions` is required on import here: https://github.com/stac-utils/stac-geoparquet/blob/e13f237be2aa341ceb21abb341fc47d8fe3efeda/stac_geoparquet/arrow/_batch.py#L15

To demonstrate (without this PR):

```shell
$ uv venv && source .venv/bin/activate && uv pip install .
$ python -c "import stac_geoparquet"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/gadomski/Code/stac-geoparquet/stac_geoparquet/__init__.py", line 3, in <module>
    from . import arrow
  File "/Users/gadomski/Code/stac-geoparquet/stac_geoparquet/arrow/__init__.py", line 1, in <module>
    from ._api import (
  File "/Users/gadomski/Code/stac-geoparquet/stac_geoparquet/arrow/_api.py", line 9, in <module>
    from stac_geoparquet.arrow._batch import StacArrowBatch, StacJsonBatch
  File "/Users/gadomski/Code/stac-geoparquet/stac_geoparquet/arrow/_batch.py", line 15, in <module>
    from typing_extensions import Self
ModuleNotFoundError: No module named 'typing_extensions'
```

Closes https://github.com/stac-utils/stac-geoparquet/issues/68