### PR TITLE
Make deltalake an optional dependency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v2
       - uses: astral-sh/setup-uv@v5

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -2,6 +2,10 @@
 
 This is a list of changes to `stac-geoparquet`.
 
+## 0.8.0
+
+- Make `deltalake` an optional dependency (https://github.com/stac-utils/stac-geoparquet/pull/106)
+
 ## 0.7.0
 
 - Updated stac-geoparquet Parquet File metadata fields (https://github.com/stac-utils/stac-geoparquet/pull/98)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dynamic = ["version", "description"]
 requires-python = ">=3.9"
 dependencies = [
     "ciso8601",
-    "deltalake",
     "geopandas",
     "packaging",
     "pandas",
@@ -33,6 +32,10 @@ source = "vcs"
 version-file = "stac_geoparquet/_version.py"
 
 [project.optional-dependencies]
+deltalake = [
+    "deltalake",
+]
+
 pgstac = [
     "fsspec",
     "psycopg[binary,pool]",
@@ -40,7 +43,14 @@ pgstac = [
     "python-dateutil",
     "tqdm",
 ]
-pc = ["adlfs", "azure-data-tables", "psycopg[binary,pool]", "pypgstac", "tqdm"]
+
+pc = [
+    "adlfs",
+    "azure-data-tables",
+    "psycopg[binary,pool]",
+    "pypgstac",
+    "tqdm"
+]
 
 [dependency-groups]
 dev = [
@@ -53,6 +63,7 @@ dev = [
     "pytest",
     "requests",
     "ruff",
+    "stac-geoparquet[deltalake]",
     "stac-geoparquet[pc]",
     "stac-geoparquet[pgstac]",
     "types-python-dateutil",

--- a/stac_geoparquet/arrow/_delta_lake.py
+++ b/stac_geoparquet/arrow/_delta_lake.py
@@ -5,7 +5,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
-from deltalake import write_deltalake
+
+try:
+    from deltalake import write_deltalake
+
+    _deltalake_installed = True
+except ImportError:
+    _deltalake_installed = False
 
 from stac_geoparquet.arrow._api import parse_stac_ndjson_to_arrow
 from stac_geoparquet.arrow._constants import DEFAULT_JSON_CHUNK_SIZE
@@ -47,6 +53,11 @@ def parse_stac_ndjson_to_delta_lake(
         schema_version: GeoParquet specification version; if not provided will default
             to latest supported version.
     """
+    if not _deltalake_installed:
+        raise ImportError(
+            "The `deltalake` package is required to use parse_stac_ndjson_to_delta_lake"
+            "Enable with `pip install stac_geoparquet[deltalake]`."
+        )
     record_batch_reader = parse_stac_ndjson_to_arrow(
         input_path, chunk_size=chunk_size, schema=schema, limit=limit
     )

--- a/tests/test_delta_lake.py
+++ b/tests/test_delta_lake.py
@@ -4,8 +4,7 @@ from pathlib import Path
 import pytest
 from deltalake import DeltaTable
 
-from stac_geoparquet.arrow import stac_table_to_items
-from stac_geoparquet.arrow._delta_lake import parse_stac_ndjson_to_delta_lake
+import stac_geoparquet.arrow
 
 from .json_equals import assert_json_value_equal
 
@@ -27,16 +26,25 @@ TEST_COLLECTIONS = [
 ]
 
 
+def test_no_deltalake_raises():
+    # Dev environment has deltalake, so pretend we don't have it
+    stac_geoparquet.arrow._delta_lake._deltalake_installed = False
+    with pytest.raises(ImportError, match="The `deltalake` package is required"):
+        stac_geoparquet.arrow.parse_stac_ndjson_to_delta_lake("foo", "bar")
+    # Reset for subsequent tests
+    stac_geoparquet.arrow._delta_lake._deltalake_installed = True
+
+
 @pytest.mark.parametrize("collection_id", TEST_COLLECTIONS)
 def test_round_trip_via_delta_lake(collection_id: str, tmp_path: Path):
     path = HERE / "data" / f"{collection_id}-pc.json"
     out_path = tmp_path / collection_id
-    parse_stac_ndjson_to_delta_lake(path, out_path)
+    stac_geoparquet.arrow.parse_stac_ndjson_to_delta_lake(path, out_path)
 
     # Read back into table and convert to json
     dt = DeltaTable(out_path)
     table = dt.to_pyarrow_table()
-    items_result = list(stac_table_to_items(table))
+    items_result = list(stac_geoparquet.arrow.stac_table_to_items(table))
 
     # Compare with original json
     with open(HERE / "data" / f"{collection_id}-pc.json") as f:

--- a/uv.lock
+++ b/uv.lock
@@ -3600,7 +3600,6 @@ name = "stac-geoparquet"
 source = { editable = "." }
 dependencies = [
     { name = "ciso8601" },
-    { name = "deltalake" },
     { name = "geopandas" },
     { name = "orjson" },
     { name = "packaging" },
@@ -3615,6 +3614,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+deltalake = [
+    { name = "deltalake" },
+]
 pc = [
     { name = "adlfs" },
     { name = "azure-data-tables" },
@@ -3642,7 +3644,7 @@ dev = [
     { name = "pytest-recording" },
     { name = "requests" },
     { name = "ruff" },
-    { name = "stac-geoparquet", extra = ["pc", "pgstac"] },
+    { name = "stac-geoparquet", extra = ["deltalake", "pc", "pgstac"] },
     { name = "types-python-dateutil" },
     { name = "types-requests", version = "2.31.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or platform_python_implementation == 'PyPy'" },
     { name = "types-requests", version = "2.32.0.20241016", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and platform_python_implementation != 'PyPy'" },
@@ -3662,7 +3664,7 @@ requires-dist = [
     { name = "adlfs", marker = "extra == 'pc'" },
     { name = "azure-data-tables", marker = "extra == 'pc'" },
     { name = "ciso8601" },
-    { name = "deltalake" },
+    { name = "deltalake", marker = "extra == 'deltalake'" },
     { name = "fsspec", marker = "extra == 'pgstac'" },
     { name = "geopandas" },
     { name = "orjson" },
@@ -3670,7 +3672,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'pc'" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'pgstac'" },
-    { name = "pyarrow", specifier = ">=16,<19" },
+    { name = "pyarrow", specifier = ">=16,!=19.0.0" },
     { name = "pypgstac", marker = "extra == 'pc'" },
     { name = "pypgstac", marker = "extra == 'pgstac'" },
     { name = "pyproj" },
@@ -3681,7 +3683,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'pgstac'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-provides-extras = ["pc", "pgstac"]
+provides-extras = ["deltalake", "pc", "pgstac"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3694,6 +3696,7 @@ dev = [
     { name = "pytest-recording", specifier = ">=0.13.2" },
     { name = "requests" },
     { name = "ruff" },
+    { name = "stac-geoparquet", extras = ["deltalake"] },
     { name = "stac-geoparquet", extras = ["pc"] },
     { name = "stac-geoparquet", extras = ["pgstac"] },
     { name = "types-python-dateutil" },


### PR DESCRIPTION
Closes #81

This moves deltalake (only required for `parse_stac_ndjson_to_delta_lake`) to a new `deltalake` optional dependency group, in order to allow using stac_geoparquet for python >=3.13

Happy to modify or defer to others if there is a better way to deal with optional dependencies these days!