### PR TITLE
Use collections (plural) for spec

### DIFF
--- a/spec/example-metadata.json
+++ b/spec/example-metadata.json
@@ -1,5 +1,44 @@
 {
     "version": "1.0.0",
+    "collections": {
+        "simple-collection": {
+            "id": "simple-collection",
+            "type": "Collection",
+            "stac_extensions": [],
+            "stac_version": "1.1.0",
+            "description": "A simple collection demonstrating core catalog fields with links to a couple of items",
+            "title": "Simple Example Collection",
+            "keywords": [
+                "simple",
+                "example",
+                "collection"
+            ],
+            "providers": [],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            172.91173669923782,
+                            1.3438851951615003,
+                            172.95469614953714,
+                            1.3690476620161975
+                        ]
+                    ]
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2020-12-11T22:38:32.125Z",
+                            "2020-12-14T18:02:31.437Z"
+                        ]
+                    ]
+                }
+            },
+            "license": "CC-BY-4.0",
+            "summaries": {},
+            "links": []
+        }
+    },
     "collection": {
         "id": "simple-collection",
         "type": "Collection",

--- a/spec/example-metadata.json
+++ b/spec/example-metadata.json
@@ -38,42 +38,5 @@
             "summaries": {},
             "links": []
         }
-    },
-    "collection": {
-        "id": "simple-collection",
-        "type": "Collection",
-        "stac_extensions": [],
-        "stac_version": "1.1.0",
-        "description": "A simple collection demonstrating core catalog fields with links to a couple of items",
-        "title": "Simple Example Collection",
-        "keywords": [
-            "simple",
-            "example",
-            "collection"
-        ],
-        "providers": [],
-        "extent": {
-            "spatial": {
-                "bbox": [
-                    [
-                        172.91173669923782,
-                        1.3438851951615003,
-                        172.95469614953714,
-                        1.3690476620161975
-                    ]
-                ]
-            },
-            "temporal": {
-                "interval": [
-                    [
-                        "2020-12-11T22:38:32.125Z",
-                        "2020-12-14T18:02:31.437Z"
-                    ]
-                ]
-            }
-        },
-        "license": "CC-BY-4.0",
-        "summaries": {},
-        "links": []
     }
 }

--- a/spec/json-schema/metadata.json
+++ b/spec/json-schema/metadata.json
@@ -10,10 +10,21 @@
       "const": "1.0.0",
       "description": "The stac-geoparquet metadata version."
     },
+    "collections": {
+      "type": "object",
+      "description": "A mapping from Collection ID to Collection object. As usual, the Collection ID used as the key of the mapping must match the ID in the Collection object.",
+      "additionalProperties": {
+        "type": "object",
+        "description": "This object represents a Collection in a SpatioTemporal Asset Catalog. Note that this object is not validated against the STAC Collection schema. You'll need to validate it separately from stac-geoparquet."
+      }
+    },
     "collection": {
       "type": "object",
-      "description": "This object represents a Collection in a SpatioTemporal Asset Catalog. Note that this object is not validated against the STAC Collection schema. You'll need to validate it separately from stac-geoparquet."
+      "description": "This object represents a Collection in a SpatioTemporal Asset Catalog. Note that this object is not validated against the STAC Collection schema. You'll need to validate it separately from stac-geoparquet.",
+      "deprecated": true
     }
   },
-  "required": ["version"]
+  "required": [
+    "version"
+  ]
 }

--- a/spec/stac-geoparquet-spec.md
+++ b/spec/stac-geoparquet-spec.md
@@ -82,10 +82,11 @@ Note that the json-schema for stac-geoparquet does *not* validate the
 separately.
 
 
-| Field Name   | Type                   | Description                                                             |
-| -------------| -----------------------| ----------------------------------------------------------------------- |
-| `version`    | string                 | The stac-geoparquet metadata version. Currently just "1.0.0" is allowed |
-| `collection` | STAC Collection object | STAC Collection metadata.                                               |
+| Field Name    | Type                    | Description                                                                                |
+| --------------| ------------------------| ------------------------------------------------------------------------------------------ |
+| `version`     | string                  | The stac-geoparquet metadata version. The stac-geoparquet version this dataset implements. |
+| `collections` | Map<string, Collection> | A mapping from collection ID to STAC collection objects.                                   |
+| `collection`  | STAC Collection object  | **deprecated**. Use `collections` instead.                                                 |
 
 Note that this metadata is distinct from the file metadata required by
 [geoparquet].
@@ -96,17 +97,31 @@ The field `version` stores the version of the stac-geoparquet
 specification the data complies with. Readers can use this field to understand what
 features and fields are available.
 
-Currently, the only allowed value is the string `"1.0.0"`.
+Currently, the only allowed values are `"1.1.0"` and `"1.0.0"`.
 
-Note: early versions of this specificaiton didn't include a `version` field. Readers
+Note: early versions of this specification didn't include a `version` field. Readers
 aiming for maximum compatibility may attempt to read files without this key present,
 despite it being required from 1.0.0 onwards.
 
-#### STAC Collection Object
+#### STAC Collection Objects
 
 To make a stac-geoparquet file a fully self-contained representation, you can
-include the Collection JSON document in the Parquet metadata under the
-`collection` key. This should contain a STAC [Collection].
+include [STAC Collection][Collection] JSON objects in the Parquet metadata
+under the `collections` key. This should be a mapping from Collection ID to
+Collection object. As usual, the ID used as the key of the mapping must match
+the ID in the Collection object.
+
+Because parquet is a columnar format and stores the union of all the fields from
+all the items, we recommend only storing STAC collections with the same or
+mostly the same fields in the same stac-geoparquet dataset. STAC collections
+with very different schemas should likely be distributed in separate
+stac-geoparquet datasets.
+
+#### STAC Collection Object
+
+Version 1.0.0 of this specification included a singular `collection` field that
+stored a single STAC collection object. In version 1.1.0, this field is
+deprecated in favor of `collections`.
 
 ## Referencing a STAC Geoparquet Collections in a STAC Collection JSON
 

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any, Literal
 
@@ -31,8 +31,8 @@ def parse_stac_ndjson_to_parquet(
     schema: pa.Schema | InferredSchema | None = None,
     limit: int | None = None,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
-    collections: dict[str, dict[str, Any]] | None = None,
-    collection_metadata: dict[str, Any] | None = None,
+    collections: Mapping[str, Mapping[str, Any]] | None = None,
+    collection_metadata: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet
@@ -83,8 +83,8 @@ def to_parquet(
     output_path: str | Path,
     *,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
-    collections: dict[str, dict[str, Any]] | None = None,
-    collection_metadata: dict[str, Any] | None = None,
+    collections: Mapping[str, Mapping[str, Any]] | None = None,
+    collection_metadata: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
     """Write an Arrow table with STAC data to GeoParquet
@@ -135,8 +135,8 @@ def create_parquet_metadata(
     schema: pa.Schema,
     *,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS,
-    collections: dict[str, dict[str, Any]] | None = None,
-    collection_metadata: dict[str, Any] | None = None,
+    collections: Mapping[str, Mapping[str, Any]] | None = None,
+    collection_metadata: Mapping[str, Any] | None = None,
 ) -> dict[bytes, bytes]:
     # TODO: include bbox of geometries
 
@@ -199,8 +199,8 @@ def schema_version_has_bbox_mapping(
 
 
 def create_stac_geoparquet_metadata(
-    collections: dict[str, dict[str, Any]] | None = None,
-    collection_metadata: dict[str, Any] | None = None,
+    collections: Mapping[str, Mapping[str, Any]] | None = None,
+    collection_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     Create the stac-geoparquet metadata object for the Parquet file.

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Literal
@@ -30,6 +31,7 @@ def parse_stac_ndjson_to_parquet(
     schema: pa.Schema | InferredSchema | None = None,
     limit: int | None = None,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
+    collections: dict[str, dict[str, Any]] | None = None,
     collection_metadata: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
@@ -49,9 +51,16 @@ def parse_stac_ndjson_to_parquet(
         limit: The maximum number of JSON records to convert.
         schema_version: GeoParquet specification version; if not provided will default
             to latest supported version.
+        collections: A dictionary mapping collection IDs to
+            dictionaries representing a Collection in a SpatioTemporal
+            Asset Catalog. This will be stored under the key `stac-geoparquet` in the
+            parquet file metadata, under the key `collections`.
+
         collection_metadata: A dictionary representing a Collection in a SpatioTemporal
             Asset Catalog. This will be stored under the key `stac-geoparquet` in the
             parquet file metadata, under the key `collection`.
+
+            Deprecated in favor of `collections`.
 
     All other keyword args are passed on to
     [`pyarrow.parquet.ParquetWriter`][pyarrow.parquet.ParquetWriter].
@@ -64,6 +73,7 @@ def parse_stac_ndjson_to_parquet(
         output_path=output_path,
         schema_version=schema_version,
         **kwargs,
+        collections=collections,
         collection_metadata=collection_metadata,
     )
 
@@ -73,6 +83,7 @@ def to_parquet(
     output_path: str | Path,
     *,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
+    collections: dict[str, dict[str, Any]] | None = None,
     collection_metadata: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> None:
@@ -91,9 +102,15 @@ def to_parquet(
     Keyword Args:
         schema_version: GeoParquet specification version; if not provided will default
             to latest supported version.
+        collections: A dictionary mapping collection IDs to
+            dictionaries representing a Collection in a SpatioTemporal
+            Asset Catalog. This will be stored under the key `stac-geoparquet` in the
+            parquet file metadata, under the key `collections`.
         collection_metadata: A dictionary representing a Collection in a SpatioTemporal
             Asset Catalog. This will be stored under the key `stac-geoparquet` in the
             parquet file metadata, under the key `collection`.
+
+            Deprecated in favor of `collections`.
 
     All other keyword args are passed on to
     [`pyarrow.parquet.ParquetWriter`][pyarrow.parquet.ParquetWriter].
@@ -105,6 +122,7 @@ def to_parquet(
         create_parquet_metadata(
             reader.schema,
             schema_version=schema_version,
+            collections=collections,
             collection_metadata=collection_metadata,
         )
     )
@@ -117,9 +135,11 @@ def create_parquet_metadata(
     schema: pa.Schema,
     *,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS,
+    collections: dict[str, dict[str, Any]] | None = None,
     collection_metadata: dict[str, Any] | None = None,
 ) -> dict[bytes, bytes]:
     # TODO: include bbox of geometries
+
     column_meta = {
         "encoding": "WKB",
         # TODO: specify known geometry types
@@ -158,7 +178,9 @@ def create_parquet_metadata(
             "crs": None,
         }
 
-    geoparquet_metadata = create_stac_geoparquet_metadata(collection_metadata)
+    geoparquet_metadata = create_stac_geoparquet_metadata(
+        collections, collection_metadata
+    )
 
     return {
         b"geo": json.dumps(geo_meta).encode("utf-8"),
@@ -177,6 +199,7 @@ def schema_version_has_bbox_mapping(
 
 
 def create_stac_geoparquet_metadata(
+    collections: dict[str, dict[str, Any]] | None = None,
     collection_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
@@ -188,6 +211,17 @@ def create_stac_geoparquet_metadata(
     result: dict[str, Any] = {
         "version": STAC_GEOPARQUET_VERSION,
     }
+
+    if collection_metadata is not None:
+        msg = (
+            "'collection_metadata' is deprecated. Provide the STAC Collection metadata as a "
+            "dictionary of '{{collection_id: collection}}' using the 'collections' keyword instead."
+        )
+        warnings.warn(msg, FutureWarning, stacklevel=3)
+
     if collection_metadata:
         result["collection"] = collection_metadata
+    if collections:
+        result["collections"] = collections
+
     return result


### PR DESCRIPTION
This updates the spec and python implementation to use `collections` (plural) for storing collection metadata.

Closes https://github.com/stac-utils/stac-geoparquet/issues/88