### PR TITLE
Fix pyarrow dataset import in _api

### DIFF
--- a/stac_geoparquet/arrow/_api.py
+++ b/stac_geoparquet/arrow/_api.py
@@ -137,9 +137,9 @@ def parse_stac_items_to_arrow(
                     output_path=fname,
                 )
                 memlog(f"Batch {cnt}")
-            ds = dataset(tmpdir, schema=schema, format="parquet", batch_size=chunk_size)
+            ds = dataset(tmpdir, schema=schema, format="parquet")
             memlog("Created Dataset")
-            batches = ds.to_batches()
+            batches = ds.to_batches(batch_size=chunk_size)
             memlog("Created Batches")
             return pa.RecordBatchReader.from_batches(schema, batches)
 

--- a/stac_geoparquet/arrow/_api.py
+++ b/stac_geoparquet/arrow/_api.py
@@ -12,6 +12,7 @@ from typing import Any
 import psutil
 import pyarrow as pa
 import pystac
+from pyarrow.dataset import dataset
 
 from stac_geoparquet.arrow._batch import StacArrowBatch, StacJsonBatch
 from stac_geoparquet.arrow._constants import (
@@ -136,9 +137,7 @@ def parse_stac_items_to_arrow(
                     output_path=fname,
                 )
                 memlog(f"Batch {cnt}")
-            ds = pa.dataset.dataset(
-                tmpdir, schema=schema, format="parquet", batch_size=chunk_size
-            )
+            ds = dataset(tmpdir, schema=schema, format="parquet", batch_size=chunk_size)
             memlog("Created Dataset")
             batches = ds.to_batches()
             memlog("Created Batches")


### PR DESCRIPTION
Currently in `parse_stac_items_to_arrow` there is an issue with referencing pyarrow dataset:
```
python3
Python 3.10.12 (main, Nov 14 2024, 15:47:05) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
Ctrl click to launch VS Code Native REPL
>>> import pyarrow as pa
>>> pa.dataset.dataset()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pyarrow' has no attribute 'dataset'
```
My change fixes the issue by importing the dataset submodule correctly, compatible with pyarrow 21.0.0 and also passes the batch_size parameter to to_batches rather than the dataset funcion.