### PR TITLE
fix: convert Path to str for remote filesystem compatibility.

### DIFF
--- a/stac_geoparquet/arrow/__init__.py
+++ b/stac_geoparquet/arrow/__init__.py
@@ -1,5 +1,6 @@
 from ._api import (
     parse_stac_items_to_arrow,
+    parse_stac_items_to_parquet,
     parse_stac_ndjson_to_arrow,
     parse_stac_ndjson_to_parquet,
     stac_table_to_items,
@@ -19,6 +20,7 @@ __all__ = (
     "DEFAULT_PARQUET_SCHEMA_VERSION",
     "ACCEPTED_SCHEMA_OPTIONS",
     "parse_stac_items_to_arrow",
+    "parse_stac_items_to_parquet",
     "parse_stac_ndjson_to_arrow",
     "parse_stac_ndjson_to_delta_lake",
     "parse_stac_ndjson_to_parquet",

--- a/stac_geoparquet/arrow/_api.py
+++ b/stac_geoparquet/arrow/_api.py
@@ -269,6 +269,7 @@ def parse_stac_ndjson_to_parquet(
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     collections: Mapping[str, Mapping[str, Any]] | None = None,
     collection_metadata: Mapping[str, Any] | None = None,
+    filesystem: pa.fs.FileSystem | None = None,
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet
@@ -297,6 +298,8 @@ def parse_stac_ndjson_to_parquet(
             parquet file metadata, under the key `collection`.
 
             Deprecated in favor of `collections`.
+        filesystem: PyArrow FileSystem to use for writing. If not provided, will be inferred
+            from output_path for local files.
 
     All other keyword args are passed on to
     [`pyarrow.parquet.ParquetWriter`][pyarrow.parquet.ParquetWriter].
@@ -308,6 +311,7 @@ def parse_stac_ndjson_to_parquet(
         record_batch_reader,
         output_path=output_path,
         schema_version=schema_version,
+        filesystem=filesystem,
         **kwargs,
         collections=collections,
         collection_metadata=collection_metadata,

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -27,6 +27,7 @@ def to_parquet(
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     collections: Mapping[str, Mapping[str, Any]] | None = None,
     collection_metadata: Mapping[str, Any] | None = None,
+    filesystem: pa.fs.FileSystem | None = None,
     **kwargs: Any,
 ) -> None:
     """Write an Arrow table with STAC data to GeoParquet
@@ -53,6 +54,8 @@ def to_parquet(
             parquet file metadata, under the key `collection`.
 
             Deprecated in favor of `collections`.
+        filesystem: PyArrow FileSystem to use for writing. If not provided, will be inferred
+            from output_path for local files.
 
     All other keyword args are passed on to
     [`pyarrow.parquet.ParquetWriter`][pyarrow.parquet.ParquetWriter].
@@ -68,7 +71,15 @@ def to_parquet(
             collection_metadata=collection_metadata,
         )
     )
-    with pq.ParquetWriter(output_path, schema, **kwargs) as writer:
+
+    # Convert Path to string for external filesystems ParquetWriter compatibility
+    path_for_writer: str = (
+        str(output_path) if isinstance(output_path, Path) else output_path
+    )
+
+    with pq.ParquetWriter(
+        path_for_writer, schema, filesystem=filesystem, **kwargs
+    ) as writer:
         for batch in reader:
             writer.write_batch(batch)
 

--- a/stac_geoparquet/arrow/_to_parquet.py
+++ b/stac_geoparquet/arrow/_to_parquet.py
@@ -72,13 +72,8 @@ def to_parquet(
         )
     )
 
-    # Convert Path to string for external filesystems ParquetWriter compatibility
-    path_for_writer: str = (
-        str(output_path) if isinstance(output_path, Path) else output_path
-    )
-
     with pq.ParquetWriter(
-        path_for_writer, schema, filesystem=filesystem, **kwargs
+        str(output_path), schema, filesystem=filesystem, **kwargs
     ) as writer:
         for batch in reader:
             writer.write_batch(batch)

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1,6 +1,6 @@
 import itertools
 import json
-from io import BytesIO
+import tempfile
 from pathlib import Path
 
 import pyarrow as pa
@@ -144,10 +144,9 @@ def test_to_parquet_two_geometry_columns():
         items = json.load(f)
 
     table = parse_stac_items_to_arrow(items).read_all()
-    with BytesIO() as bio:
-        to_parquet(table, bio)
-        bio.seek(0)
-        pq_meta = pq.read_metadata(bio)
+    with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+        to_parquet(table, f.name)
+        pq_meta = pq.read_metadata(f.name)
 
     geo_meta = json.loads(pq_meta.metadata[b"geo"])
     assert geo_meta["primary_column"] == "geometry"

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -10,6 +10,7 @@ import pytest
 from stac_geoparquet.arrow import (
     DEFAULT_JSON_CHUNK_SIZE,
     parse_stac_items_to_arrow,
+    parse_stac_items_to_parquet,
     parse_stac_ndjson_to_arrow,
     stac_table_to_items,
     stac_table_to_ndjson,
@@ -152,3 +153,58 @@ def test_to_parquet_two_geometry_columns():
     assert geo_meta["primary_column"] == "geometry"
     assert "geometry" in geo_meta["columns"].keys()
     assert "proj:geometry" in geo_meta["columns"].keys()
+
+
+def test_to_parquet_with_nonlocal_filesystem(tmp_path: Path):
+    """Test to_parquet with filesystem parameter and Path object.
+
+    This test verifies that Path objects are properly converted to strings
+    when using remote/non-local filesystems, which is required for compatibility
+    with PyArrow's ParquetWriter.
+    """
+    collection_id = "naip-pc"
+    with open(HERE / "data" / f"{collection_id}.json") as f:
+        items = json.load(f)
+
+    table = parse_stac_items_to_arrow(items).read_all()
+
+    mock_fs = pa.fs.SubTreeFileSystem(str(tmp_path), pa.fs.LocalFileSystem())
+    output_path = Path("test.parquet")
+
+    to_parquet(table, output_path, filesystem=mock_fs)
+
+    actual_file = tmp_path / "test.parquet"
+    assert actual_file.exists()
+    result_table = pq.read_table(str(actual_file))
+    assert result_table.num_rows == table.num_rows
+
+
+def test_parse_stac_items_to_parquet_with_filesystem(tmp_path: Path):
+    """Test parse_stac_items_to_parquet with filesystem parameter."""
+    collection_id = "naip-pc"
+    with open(HERE / "data" / f"{collection_id}.json") as f:
+        items = json.load(f)
+
+    mock_fs = pa.fs.SubTreeFileSystem(str(tmp_path), pa.fs.LocalFileSystem())
+
+    # Test Path object (tests the str conversion fix)
+    output_path = Path("test_path.parquet")
+    parse_stac_items_to_parquet(items, output_path=output_path, filesystem=mock_fs)
+    actual_file = tmp_path / "test_path.parquet"
+    assert actual_file.exists()
+    result_table = pq.read_table(str(actual_file))
+    assert result_table.num_rows > 0
+
+    # Test nested directory with Path
+    output_nested = Path("output/data/test.parquet")
+    parse_stac_items_to_parquet(items, output_path=output_nested, filesystem=mock_fs)
+    actual_nested = tmp_path / "output" / "data" / "test.parquet"
+    assert actual_nested.exists()
+    assert pq.read_table(str(actual_nested)).num_rows > 0
+
+    # Test String path (backward compatibility)
+    output_string = "test_string.parquet"
+    parse_stac_items_to_parquet(items, output_path=output_string, filesystem=mock_fs)
+    actual_string = tmp_path / "test_string.parquet"
+    assert actual_string.exists()
+    assert pq.read_table(str(actual_string)).num_rows > 0

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1,6 +1,5 @@
 import itertools
 import json
-import tempfile
 from pathlib import Path
 
 import pyarrow as pa
@@ -134,9 +133,9 @@ def test_from_arrow_deprecated():
     stac_geoparquet.from_arrow.stac_table_to_items
 
 
-def test_to_parquet_two_geometry_columns():
+def test_to_parquet_two_geometry_columns(tmp_path: Path):
     """
-    When writing STAC Items that have a proj:geometry field, there should be two
+     When writing STAC Items that have a proj:geometry field, there should be two
     geometry columns listed in the GeoParquet metadata.
     """
     collection_id = "3dep-lidar-copc-pc"
@@ -144,21 +143,9 @@ def test_to_parquet_two_geometry_columns():
         items = json.load(f)
 
     table = parse_stac_items_to_arrow(items).read_all()
-    with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
-        to_parquet(table, f.name)
-def test_to_parquet_two_geometry_columns(tmp_path: Path):
-"""
-   When writing STAC Items that have a proj:geometry field, there should be two
-   geometry columns listed in the GeoParquet metadata.
-   """
-collection_id = "3dep-lidar-copc-pc"
-with open(HERE / "data" / f"{collection_id}.json") as f:
-items = json.load(f)
-
-table = parse_stac_items_to_arrow(items).read_all()
-path = tmp_path / "output.parquet"
-      to_parquet(table, path)
-      pq_meta = pq.read_metadata(path)
+    path = tmp_path / "output.parquet"
+    to_parquet(table, path)
+    pq_meta = pq.read_metadata(path)
 
     geo_meta = json.loads(pq_meta.metadata[b"geo"])
     assert geo_meta["primary_column"] == "geometry"

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -146,7 +146,19 @@ def test_to_parquet_two_geometry_columns():
     table = parse_stac_items_to_arrow(items).read_all()
     with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
         to_parquet(table, f.name)
-        pq_meta = pq.read_metadata(f.name)
+def test_to_parquet_two_geometry_columns(tmp_path: Path):
+"""
+   When writing STAC Items that have a proj:geometry field, there should be two
+   geometry columns listed in the GeoParquet metadata.
+   """
+collection_id = "3dep-lidar-copc-pc"
+with open(HERE / "data" / f"{collection_id}.json") as f:
+items = json.load(f)
+
+table = parse_stac_items_to_arrow(items).read_all()
+path = tmp_path / "output.parquet"
+      to_parquet(table, path)
+      pq_meta = pq.read_metadata(path)
 
     geo_meta = json.loads(pq_meta.metadata[b"geo"])
     assert geo_meta["primary_column"] == "geometry"

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import jsonschema
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 import requests
@@ -108,3 +109,16 @@ def test_metadata(tmp_path: Path, *, write_collections: bool) -> None:
         "https://radiantearth.github.io/stac-geoparquet-spec/0.7.0/json-schema/metadata.json"
     ).json()
     jsonschema.validate(stac_geoparquet_metadata, schema)
+
+
+def test_parse_stac_ndjson_to_parquet_with_filesystem(tmp_path: Path):
+    collection_id = "naip-pc"
+    input_path = HERE / "data" / f"{collection_id}.json"
+    mock_fs = pa.fs.SubTreeFileSystem(str(tmp_path), pa.fs.LocalFileSystem())
+
+    # Test simple Path object (tests the str conversion fix)
+    output_path = Path("test.parquet")
+    parse_stac_ndjson_to_parquet(input_path, output_path, filesystem=mock_fs)
+    actual_file = tmp_path / "test.parquet"
+    assert actual_file.exists()
+    assert pq.read_table(str(actual_file)).num_rows > 0


### PR DESCRIPTION
Fixes a bug where `stac-geoparquet` fails when writing Parquet files to s3 with the error:

```
TypeError: Expected string path; path-like objects are only allowed with a local filesystem
```

The problem is that PyArrow's `ParquetWriter` has different requirements for local vs remote filesystems:
- **Local filesystems**: Accept both `str` and `Path` objects
- **Remote filesystems** (S3): Only accept `str` paths

The `to_parquet()` function was passing `Path` objects directly to `ParquetWriter`, which works for local files but fails for remote storage.

Therefore the proposed solution is to always convert `Path` to `str` before passing to `ParquetWriter`.