### PR TITLE
fix: Partition type hint and scheme-prefixed output_path mangling

### DIFF
--- a/stac_geoparquet/arrow/_api.py
+++ b/stac_geoparquet/arrow/_api.py
@@ -23,7 +23,10 @@ from stac_geoparquet.arrow._constants import (
 )
 from stac_geoparquet.arrow._schema.models import InferredSchema
 from stac_geoparquet.arrow._to_parquet import to_parquet
-from stac_geoparquet.arrow._util import batched_iter
+from stac_geoparquet.arrow._util import (
+    batched_iter,
+    resolve_output_path_and_filesystem,
+)
 from stac_geoparquet.arrow.types import ArrowStreamExportable
 from stac_geoparquet.json_reader import read_json_chunked
 
@@ -160,10 +163,7 @@ def parse_stac_items_to_parquet(
     """
     logger.info("Saving STAC Items to Parquet")
 
-    if filesystem is None:
-        filesystem, filepath = pa.fs.FileSystem.from_uri(output_path)
-    else:
-        filepath = output_path
+    filesystem, filepath = resolve_output_path_and_filesystem(output_path, filesystem)
 
     filedir = Path(filepath).parent
     filesystem.create_dir(str(filedir), recursive=True)

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -3,10 +3,8 @@ from collections.abc import Iterable, Sequence
 from functools import reduce
 from itertools import islice
 from pathlib import Path
-from typing import (
-    Any,
-    TypeVar,
-)
+from typing import Any, TypeVar
+from urllib.parse import urlsplit
 
 import pyarrow as pa
 
@@ -21,8 +19,8 @@ def resolve_output_path_and_filesystem(
     if filesystem is None:
         return pa.fs.FileSystem.from_uri(output_path)
     if isinstance(output_path, str) and "://" in output_path:
-        _, filepath = pa.fs.FileSystem.from_uri(output_path)
-        return filesystem, filepath
+        parsed = urlsplit(output_path)
+        return filesystem, f"{parsed.netloc}{parsed.path}"
     return filesystem, output_path
 
 

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -14,14 +14,14 @@ T = TypeVar("T")
 def resolve_output_path_and_filesystem(
     output_path: str | Path,
     filesystem: pa.fs.FileSystem | None,
-) -> tuple[pa.fs.FileSystem, str | Path]:
+) -> tuple[pa.fs.FileSystem, str]:
     """Resolve an (output_path, filesystem) pair, normalizing scheme-prefixed URIs."""
     if filesystem is None:
         return pa.fs.FileSystem.from_uri(output_path)
     if isinstance(output_path, str) and "://" in output_path:
         parsed = urlsplit(output_path)
         return filesystem, f"{parsed.netloc}{parsed.path}"
-    return filesystem, output_path
+    return filesystem, str(output_path)
 
 
 def update_batch_schema(

--- a/stac_geoparquet/arrow/_util.py
+++ b/stac_geoparquet/arrow/_util.py
@@ -2,6 +2,7 @@ import operator
 from collections.abc import Iterable, Sequence
 from functools import reduce
 from itertools import islice
+from pathlib import Path
 from typing import (
     Any,
     TypeVar,
@@ -10,6 +11,19 @@ from typing import (
 import pyarrow as pa
 
 T = TypeVar("T")
+
+
+def resolve_output_path_and_filesystem(
+    output_path: str | Path,
+    filesystem: pa.fs.FileSystem | None,
+) -> tuple[pa.fs.FileSystem, str | Path]:
+    """Resolve an (output_path, filesystem) pair, normalizing scheme-prefixed URIs."""
+    if filesystem is None:
+        return pa.fs.FileSystem.from_uri(output_path)
+    if isinstance(output_path, str) and "://" in output_path:
+        _, filepath = pa.fs.FileSystem.from_uri(output_path)
+        return filesystem, filepath
+    return filesystem, output_path
 
 
 def update_batch_schema(

--- a/stac_geoparquet/pgstac_reader.py
+++ b/stac_geoparquet/pgstac_reader.py
@@ -268,8 +268,8 @@ def pgstac_to_parquet(
 class Partition:
     collection: str
     partition: str
-    start: datetime
-    end: datetime
+    start: datetime | None
+    end: datetime | None
     last_updated: datetime
 
 

--- a/stac_geoparquet/pgstac_reader.py
+++ b/stac_geoparquet/pgstac_reader.py
@@ -24,6 +24,7 @@ from stac_geoparquet.arrow import (
     parse_stac_items_to_arrow,
 )
 from stac_geoparquet.arrow._api import parse_stac_items_to_parquet
+from stac_geoparquet.arrow._util import resolve_output_path_and_filesystem
 
 logger = logging.getLogger(__name__)
 
@@ -232,10 +233,7 @@ def pgstac_to_parquet(
     """
     Convert pgstac items to a parquet file.
     """
-    if filesystem is None:
-        filesystem, filepath = pyarrow.fs.FileSystem.from_uri(output_path)
-    else:
-        filepath = output_path
+    filesystem, filepath = resolve_output_path_and_filesystem(output_path, filesystem)
 
     filedir = Path(filepath).parent
     filesystem.create_dir(str(filedir), recursive=True)
@@ -257,7 +255,7 @@ def pgstac_to_parquet(
         items,
         chunk_size=chunk_size,
         schema=schema,
-        output_path=output_path,
+        output_path=filepath,
         schema_version=schema_version,
         filesystem=filesystem,
         **kwargs,
@@ -327,10 +325,7 @@ def sync_pgstac_to_parquet(
     items to parquet.
     """
 
-    if filesystem is None:
-        filesystem, filepath = pyarrow.fs.FileSystem.from_uri(output_path)
-    else:
-        filepath = output_path
+    filesystem, filepath = resolve_output_path_and_filesystem(output_path, filesystem)
 
     filedir = Path(filepath)
     filesystem.create_dir(str(filedir), recursive=True)

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -242,7 +242,7 @@ def test_parse_stac_items_to_parquet_with_scheme_prefixed_output_path(
         ("file:///test", "/test", None),
         ("file:///test", "/test", pa.fs.LocalFileSystem()),
         (Path("/test"), "/test", None),
-        (Path("/test"), Path("/test"), pa.fs.LocalFileSystem()),
+        (Path("/test"), "/test", pa.fs.LocalFileSystem()),
         ("s3://bucket/key", "bucket/key", None),
         ("s3://bucket/key", "bucket/key", pa.fs.S3FileSystem(anonymous=True)),
     ],

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -206,3 +206,30 @@ def test_parse_stac_items_to_parquet_with_filesystem(tmp_path: Path):
     actual_string = tmp_path / "test_string.parquet"
     assert actual_string.exists()
     assert pq.read_table(str(actual_string)).num_rows > 0
+
+
+def test_parse_stac_items_to_parquet_with_scheme_prefixed_output_path(
+    tmp_path: Path,
+):
+    """
+    Regression test for output path mangling in `parse_stac_items_to_parquet`
+
+    When a filesystem and scheme-prefixed `output_path` is explicitly provided, the
+    scheme-prefixed output_path (e.g., "file://folder/item.parquet") must be resolved
+    to a filesystem-relative path before being run through `Path`, since
+    `Path("file://folder/item.parquet")` collapses the double slash after the scheme
+    (e.g., "file:/folder/item.parquet").
+    """
+    collection_id = "naip-pc"
+    with open(HERE / "data" / f"{collection_id}.json") as f:
+        items = json.load(f)
+
+    filesystem = pa.fs.LocalFileSystem()
+    output_path = f"file://{tmp_path}/nested/items.parquet"
+
+    parse_stac_items_to_parquet(items, output_path=output_path, filesystem=filesystem)
+
+    actual_file = tmp_path / "nested" / "items.parquet"
+    assert actual_file.exists()
+    result_table = pq.read_table(str(actual_file))
+    assert result_table.num_rows > 0

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -15,6 +15,7 @@ from stac_geoparquet.arrow import (
     stac_table_to_ndjson,
     to_parquet,
 )
+from stac_geoparquet.arrow._util import resolve_output_path_and_filesystem
 
 from .json_equals import assert_json_value_equal
 
@@ -233,3 +234,28 @@ def test_parse_stac_items_to_parquet_with_scheme_prefixed_output_path(
     assert actual_file.exists()
     result_table = pq.read_table(str(actual_file))
     assert result_table.num_rows > 0
+
+
+@pytest.mark.parametrize(
+    ["output_path", "expected_path", "filesystem"],
+    [
+        ("file:///test", "/test", None),
+        ("file:///test", "/test", pa.fs.LocalFileSystem()),
+        (Path("/test"), "/test", None),
+        (Path("/test"), Path("/test"), pa.fs.LocalFileSystem()),
+        ("s3://bucket/key", "bucket/key", None),
+        ("s3://bucket/key", "bucket/key", pa.fs.S3FileSystem(anonymous=True)),
+    ],
+)
+def test_resolve_output_path_and_filesystem(
+    output_path: str | Path,
+    expected_path: str | Path,
+    filesystem: pa.fs.FileSystem | None,
+):
+    """Ensure output_path is parsed correctly with or without filesystem provided"""
+    returned_filesystem, returned_path = resolve_output_path_and_filesystem(
+        output_path, filesystem
+    )
+    assert returned_path == expected_path
+    if filesystem is not None:
+        assert returned_filesystem is filesystem

--- a/tests/test_pgstac_reader.py
+++ b/tests/test_pgstac_reader.py
@@ -1,13 +1,17 @@
 import json
 import pathlib
+from datetime import datetime
 
 import docker
+import pyarrow.fs
 import pypgstac
 import pytest
 from pypgstac.db import PgstacDB
 from pypgstac.load import Loader
 
+from stac_geoparquet import pgstac_reader
 from stac_geoparquet.pgstac_reader import (
+    Partition,
     pgstac_dsn,
     pgstac_to_arrow,
     pgstac_to_iter,
@@ -17,6 +21,48 @@ HERE = pathlib.Path(__file__).parent
 
 DOCKERIMG = "ghcr.io/stac-utils/pgstac:latest"
 NAIPDATA = HERE / "data" / "naip-pc.json"
+
+
+def test_sync_pgstac_to_parquet_with_scheme_prefixed_output_path(tmp_path, monkeypatch):
+    """
+    Regression test for output path mangling in `sync_pgstac_to_parquet`
+
+    When specifying a schema prefixed `output_path` with a `filesystem` the code had
+    previously parsed the `output_path` into a `filepath` using `FileSystem.from_uri`,
+    but still used `output_path` through `Path()`. This caused inputs like
+    `s3://bucket/key` to be mangled into `s3:/bucket/key` (note the single slash after
+    scheme), causing a failure inside of `FileSystem.create_dir`.
+    """
+    partition = Partition(
+        collection="naip",
+        partition="items.parquet",
+        start=None,
+        end=None,
+        last_updated=datetime(2024, 1, 1),
+    )
+    monkeypatch.setattr(
+        pgstac_reader, "get_pgstac_partitions", lambda *a, **k: iter([partition])
+    )
+
+    captured: dict = {}
+
+    def fake_pgstac_to_parquet(
+        conninfo: str, output_path: str | pathlib.Path, **kwargs
+    ) -> str:
+        captured["output_path"] = output_path
+        return str(output_path)
+
+    monkeypatch.setattr(pgstac_reader, "pgstac_to_parquet", fake_pgstac_to_parquet)
+
+    filesystem = pyarrow.fs.LocalFileSystem()
+    output_path = f"file://{tmp_path}/root"
+
+    pgstac_reader.sync_pgstac_to_parquet(
+        "postgres://unused", output_path, filesystem=filesystem
+    )
+
+    assert (tmp_path / "root").exists()
+    assert "naip" in str(captured["output_path"])
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Technical Context

- **Related Issues:** N/A but happy to open if that helps!
- **Breaking Changes:** No

## Description

This PR addresses two issues I had when using `stac-geoparquet` to dump our PgSTAC catalog into STAC GeoParquet.

1. The type hint on `Partition.[start | end]` should be nullable since Collections in PgSTAC without a `partition_trunc` will have an `[-infinity, infinity]` date range, causing the values to both be `None`.
    - Fix: c844bf89e666e9d1f3452223275c5d5a00292369
2. A scheme-prefixed `output_path` given to `to_parquet` is mangled by `Path()` when a `filesystem` is passed.
    - This wasn't captured in existing tests (no scheme-prefixed test data like `file://` or `s3://`), so I added a new regression test. Happy to merge if that is preferred.
    - This may not have been caught before because it requires setting _both_ `output_path` as scheme-prefixed **and** passing a `filesystem`. Alternatively someone could have provided a `filesystem` and an `output_path` like `"bucket/key.parquet"`
    - Regression test: 79cbac57b91b9697631411d645b99ee91dbc4731
    - Fix: 5b751789f257eabf130cee876e9f14731fd2ca5e

---

## Checklist

- [x] **Linting:** Code is formatted and linted
- [x] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [x] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [x] **Documentation:** I have updated `README.md` to reflect any new environment variables, configuration changes, or breaking updates.
- [x] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage

- [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://stac-utils.github.io/ai-contribution-policy). Use of AI tools *must* be indicated.
    - I had Claude prototype regression test that I rewrote

---

> **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.