### PR TITLE
fix: STAC properties and top level keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This is a list of changes to `stac-geoparquet`.
 
 ## Unreleased
 
-- Drop Python 3.9
+- Drop Python 3.9 (<https://github.com/stac-utils/stac-geoparquet/pull/133>)
+- Fixed resolution of scheme-prefixed `output_path`s (e.g., `s3://bucket/item.parquet`) (<https://github.com/stac-utils/stac-geoparquet/pull/143>)
+- Fixed duplication of STAC Item properties with top-level keys (e.g., "collection") (<https://github.com/stac-utils/stac-geoparquet/pull/144>)
 
 ## 0.8.0
 

--- a/stac_geoparquet/arrow/_api.py
+++ b/stac_geoparquet/arrow/_api.py
@@ -69,6 +69,7 @@ def parse_stac_items_to_arrow(
     chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
     schema: ACCEPTED_SCHEMA_OPTIONS = "FullFile",
     tmpdir: str | Path | None = None,
+    drop_invalid_properties: bool = True,
 ) -> pa.RecordBatchReader:
     """
     Parse a collection of STAC Items to an iterable of
@@ -90,6 +91,8 @@ def parse_stac_items_to_arrow(
             will use the first batch of items to infer the schema, or "ChunksToDisk"
             which will write each chunk of items to disk as a Parquet file and then read
             them back in to unify the schema. Defaults to "FullFile".
+        drop_invalid_properties: If True (default), an Item property whose name
+            collides with a top-level field. If False, a ValueError is raised instead.
 
     Returns:
         pyarrow RecordBatchReader with a stream of STAC Arrow RecordBatches.
@@ -103,19 +106,24 @@ def parse_stac_items_to_arrow(
         # If schema is provided, then for better memory usage we parse input STAC items
         # to Arrow batches in chunks.
         batches = (
-            stac_items_to_arrow(batch, schema=schema)
+            stac_items_to_arrow(
+                batch, schema=schema, drop_invalid_properties=drop_invalid_properties
+            )
             for batch in batched_iter(items, chunk_size)
         )
         return pa.RecordBatchReader.from_batches(schema, batches)
 
     elif schema == "FullFile":
-        batch = stac_items_to_arrow(items)
+        batch = stac_items_to_arrow(
+            items, drop_invalid_properties=drop_invalid_properties
+        )
         logger.debug(batch.schema, batch)
         return pa.RecordBatchReader.from_batches(batch.schema, [batch])
 
     elif schema == "FirstBatch":
         batches = (
-            stac_items_to_arrow(batch) for batch in batched_iter(items, chunk_size)
+            stac_items_to_arrow(batch, drop_invalid_properties=drop_invalid_properties)
+            for batch in batched_iter(items, chunk_size)
         )
         return from_batches(batches)
 
@@ -126,7 +134,9 @@ def parse_stac_items_to_arrow(
         else:
             logger.info(f"Using temporary directory {tmpdir} for chunked schema")
             for cnt, chunk in enumerate(batched_iter(items, chunk_size)):
-                batch = stac_items_to_arrow(chunk)
+                batch = stac_items_to_arrow(
+                    chunk, drop_invalid_properties=drop_invalid_properties
+                )
                 if not isinstance(schema, pa.Schema):
                     schema = batch.schema
                 elif not schema.equals(batch.schema):
@@ -156,6 +166,7 @@ def parse_stac_items_to_parquet(
     tmpdir: str | Path | None = None,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     filesystem: pa.fs.FileSystem | None = None,
+    drop_invalid_properties: bool = True,
     **kwargs: Any,
 ) -> str:
     """
@@ -177,6 +188,7 @@ def parse_stac_items_to_parquet(
                 chunk_size=chunk_size,
                 schema=schema,
                 tmpdir=td,
+                drop_invalid_properties=drop_invalid_properties,
             )
             memlog("Parsed to arrow")
             to_parquet(
@@ -192,6 +204,7 @@ def parse_stac_items_to_parquet(
             chunk_size=chunk_size,
             schema=schema,
             tmpdir=tmpdir,
+            drop_invalid_properties=drop_invalid_properties,
         )
         memlog("Parsed to arrow")
         to_parquet(
@@ -211,6 +224,7 @@ def parse_stac_ndjson_to_arrow(
     chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
     schema: pa.Schema | None = None,
     limit: int | None = None,
+    drop_invalid_properties: bool = True,
 ) -> pa.RecordBatchReader:
     """
     Convert one or more newline-delimited JSON STAC files to a generator of Arrow
@@ -229,6 +243,8 @@ def parse_stac_ndjson_to_arrow(
 
     Keyword Args:
         limit: The maximum number of JSON Items to use for schema inference
+        drop_invalid_properties: If True (default), an Item property whose name
+            collides with a top-level field. If False, a ValueError is raised instead.
 
     Returns:
         pyarrow RecordBatchReader with a stream of STAC Arrow RecordBatches.
@@ -240,14 +256,19 @@ def parse_stac_ndjson_to_arrow(
         inferred_schema.update_from_json(path, chunk_size=chunk_size, limit=limit)
         inferred_schema.manual_updates()
         return parse_stac_ndjson_to_arrow(
-            path, chunk_size=chunk_size, schema=inferred_schema
+            path,
+            chunk_size=chunk_size,
+            schema=inferred_schema,
+            drop_invalid_properties=drop_invalid_properties,
         )
 
     if isinstance(schema, InferredSchema):
         schema = schema.inner
 
     batches_iter = (
-        stac_items_to_arrow(batch, schema=schema)
+        stac_items_to_arrow(
+            batch, schema=schema, drop_invalid_properties=drop_invalid_properties
+        )
         for batch in read_json_chunked(path, chunk_size=chunk_size)
     )
     first_batch = next(batches_iter)
@@ -270,6 +291,7 @@ def parse_stac_ndjson_to_parquet(
     collections: Mapping[str, Mapping[str, Any]] | None = None,
     collection_metadata: Mapping[str, Any] | None = None,
     filesystem: pa.fs.FileSystem | None = None,
+    drop_invalid_properties: bool = True,
     **kwargs: Any,
 ) -> None:
     """Convert one or more newline-delimited JSON STAC files to GeoParquet
@@ -300,12 +322,18 @@ def parse_stac_ndjson_to_parquet(
             Deprecated in favor of `collections`.
         filesystem: PyArrow FileSystem to use for writing. If not provided, will be inferred
             from output_path for local files.
+        drop_invalid_properties: If True (default), an Item property whose name
+            collides with a top-level field. If False, a ValueError is raised instead.
 
     All other keyword args are passed on to
     [`pyarrow.parquet.ParquetWriter`][pyarrow.parquet.ParquetWriter].
     """
     record_batch_reader = parse_stac_ndjson_to_arrow(
-        input_path, chunk_size=chunk_size, schema=schema, limit=limit
+        input_path,
+        chunk_size=chunk_size,
+        schema=schema,
+        limit=limit,
+        drop_invalid_properties=drop_invalid_properties,
     )
     to_parquet(
         record_batch_reader,
@@ -378,7 +406,10 @@ def stac_table_to_ndjson(
 
 
 def stac_items_to_arrow(
-    items: Iterable[pystac.Item | dict[str, Any]], *, schema: pa.Schema | None = None
+    items: Iterable[pystac.Item | dict[str, Any]],
+    *,
+    schema: pa.Schema | None = None,
+    drop_invalid_properties: bool = True,
 ) -> pa.RecordBatch:
     """Convert dicts representing STAC Items to Arrow
 
@@ -394,9 +425,11 @@ def stac_items_to_arrow(
     Kwargs:
         schema: An optional schema that describes the format of the data. Note that this
             must represent the geometry column as binary type.
+        drop_invalid_properties: If True (default), an Item property whose name
+            collides with a top-level field. If False, a ValueError is raised instead.
 
     Returns:
         Arrow RecordBatch with items in Arrow
     """
     raw_batch = StacJsonBatch.from_dicts(items, schema=schema)
-    return raw_batch.to_arrow_batch().inner
+    return raw_batch.to_arrow_batch(drop_invalid_properties).inner

--- a/stac_geoparquet/arrow/_batch.py
+++ b/stac_geoparquet/arrow/_batch.py
@@ -183,7 +183,9 @@ class StacJsonBatch:
     def to_arrow_batch(self, drop_invalid_properties: bool = True) -> StacArrowBatch:
         batch = self.inner
 
-        batch = bring_properties_to_top_level(batch, drop_invalid_properties)
+        batch = bring_properties_to_top_level(
+            batch, drop_invalid_properties=drop_invalid_properties
+        )
         batch = convert_timestamp_columns(batch)
         batch = convert_bbox_to_struct(batch)
         batch = assign_geoarrow_metadata(batch)

--- a/stac_geoparquet/arrow/_batch.py
+++ b/stac_geoparquet/arrow/_batch.py
@@ -180,10 +180,10 @@ class StacJsonBatch:
 
             yield row_dict
 
-    def to_arrow_batch(self) -> StacArrowBatch:
+    def to_arrow_batch(self, drop_invalid_properties: bool = True) -> StacArrowBatch:
         batch = self.inner
 
-        batch = bring_properties_to_top_level(batch)
+        batch = bring_properties_to_top_level(batch, drop_invalid_properties)
         batch = convert_timestamp_columns(batch)
         batch = convert_bbox_to_struct(batch)
         batch = assign_geoarrow_metadata(batch)

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -1,5 +1,7 @@
 """Convert STAC data into Arrow tables"""
 
+import logging
+
 import numpy as np
 import orjson
 import pyarrow as pa
@@ -7,16 +9,32 @@ import pyarrow.compute as pc
 
 from stac_geoparquet.arrow._crs import WGS84_CRS_JSON
 
+logger = logging.getLogger(__name__)
+
 
 def bring_properties_to_top_level(
     batch: pa.RecordBatch,
 ) -> pa.RecordBatch:
-    """Bring all the fields inside of the nested "properties" struct to the top level"""
+    """Bring all the fields inside of the nested "properties" struct to the top level
+
+    A property whose name collides with an existing top-level field (e.g. a
+    redundant `properties.collection` key) is dropped rather than flattened, since
+    flattening it would produce two top-level columns with the same name - a
+    schema pyarrow's Dataset scanner refuses to unify.
+    """
     properties_field = batch.schema.field("properties")
     properties_column = batch["properties"]
+    top_level_names = set(batch.schema.names)
 
     for field_idx in range(properties_field.type.num_fields):
         inner_prop_field = properties_field.type.field(field_idx)
+        if inner_prop_field.name in top_level_names:
+            logger.warning(
+                f"Item properties contains a '{inner_prop_field.name}' key, which "
+                "collides with a top-level field of the same name. Dropping "
+                f"properties.{inner_prop_field.name}."
+            )
+            continue
         batch = batch.append_column(
             inner_prop_field,
             pc.struct_field(properties_column, field_idx),  # type: ignore

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -14,13 +14,16 @@ logger = logging.getLogger(__name__)
 
 def bring_properties_to_top_level(
     batch: pa.RecordBatch,
+    drop_invalid_properties: bool = True,
 ) -> pa.RecordBatch:
     """Bring all the fields inside of the nested "properties" struct to the top level
 
-    A property whose name collides with an existing top-level field (e.g. a
-    redundant `properties.collection` key) is dropped rather than flattened, since
-    flattening it would produce two top-level columns with the same name - a
-    schema pyarrow's Dataset scanner refuses to unify.
+    A property whose name collides with an existing top-level field is not flattened,
+    since flattening it would produce two top-level columns with the same name. STAC
+    GeoParquet does not support properties that collide with a top-level key.
+
+    If `drop_invalid_properties` is True (the default), the colliding property is
+    dropped and a warning is logged. If False, a ValueError is raised instead.
     """
     properties_field = batch.schema.field("properties")
     properties_column = batch["properties"]
@@ -29,6 +32,11 @@ def bring_properties_to_top_level(
     for field_idx in range(properties_field.type.num_fields):
         inner_prop_field = properties_field.type.field(field_idx)
         if inner_prop_field.name in top_level_names:
+            if not drop_invalid_properties:
+                raise ValueError(
+                    f"Item properties contains a '{inner_prop_field.name}' key, "
+                    "which collides with a top-level field of the same name."
+                )
             logger.warning(
                 f"Item properties contains a '{inner_prop_field.name}' key, which "
                 "collides with a top-level field of the same name. Dropping "

--- a/stac_geoparquet/arrow/_to_arrow.py
+++ b/stac_geoparquet/arrow/_to_arrow.py
@@ -32,16 +32,13 @@ def bring_properties_to_top_level(
     for field_idx in range(properties_field.type.num_fields):
         inner_prop_field = properties_field.type.field(field_idx)
         if inner_prop_field.name in top_level_names:
-            if not drop_invalid_properties:
-                raise ValueError(
-                    f"Item properties contains a '{inner_prop_field.name}' key, "
-                    "which collides with a top-level field of the same name."
-                )
-            logger.warning(
-                f"Item properties contains a '{inner_prop_field.name}' key, which "
-                "collides with a top-level field of the same name. Dropping "
-                f"properties.{inner_prop_field.name}."
+            error_info = (
+                f"Item properties contains a '{inner_prop_field.name}' key, "
+                "which collides with a top-level field of the same name."
             )
+            if not drop_invalid_properties:
+                raise ValueError(error_info)
+            logger.warning(f"{error_info} Dropping properties.{inner_prop_field.name}.")
             continue
         batch = batch.append_column(
             inner_prop_field,

--- a/stac_geoparquet/pgstac_reader.py
+++ b/stac_geoparquet/pgstac_reader.py
@@ -196,6 +196,7 @@ def pgstac_to_arrow(
     statement_timeout: int | None = None,
     row_func: Callable | None = None,
     tmpdir: str | Path | None = None,
+    drop_invalid_properties: bool = True,
 ) -> pa.RecordBatchReader:
     """
     Convert pgstac items to an arrow record batch reader.
@@ -211,7 +212,11 @@ def pgstac_to_arrow(
         row_func=row_func,
     )
     return parse_stac_items_to_arrow(
-        items, chunk_size=chunk_size, schema=schema, tmpdir=tmpdir
+        items,
+        chunk_size=chunk_size,
+        schema=schema,
+        tmpdir=tmpdir,
+        drop_invalid_properties=drop_invalid_properties,
     )
 
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -263,7 +263,7 @@ def test_resolve_output_path_and_filesystem(
 
 
 @pytest.mark.parametrize("colliding_key", ["collection", "geometry"])
-def test_properties_key_colliding_with_top_level_field_is_dropped(
+def test_properties_key_colliding_with_top_level_field(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
     colliding_key: str,
@@ -289,14 +289,10 @@ def test_properties_key_colliding_with_top_level_field_is_dropped(
         "collection": "test",
     }
 
+    with pytest.raises(ValueError, match=colliding_key):
+        parse_stac_items_to_arrow([item], drop_invalid_properties=False).read_all()
+
     with caplog.at_level("WARNING"):
         table = parse_stac_items_to_arrow([item]).read_all()
     assert f"properties.{colliding_key}" in caplog.text
     assert table.schema.names.count(colliding_key) == 1
-
-    # Real-world failure mode: a duped column breaks pyarrow's Dataset schema unification.
-    output_path = tmp_path / "items.parquet"
-    parse_stac_items_to_parquet([item], output_path=output_path)
-
-    dataset = pyarrow.dataset.dataset(str(output_path), format="parquet")
-    assert dataset.schema.names.count(colliding_key) == 1

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 import pyarrow as pa
+import pyarrow.dataset
 import pyarrow.parquet as pq
 import pytest
 
@@ -259,3 +260,43 @@ def test_resolve_output_path_and_filesystem(
     assert returned_path == expected_path
     if filesystem is not None:
         assert returned_filesystem is filesystem
+
+
+@pytest.mark.parametrize("colliding_key", ["collection", "geometry"])
+def test_properties_key_colliding_with_top_level_field_is_dropped(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    colliding_key: str,
+):
+    """Regression test to avoid clobbering top level metadata with properties
+
+    Per STAC GeoParquet specification:
+    > STAC GeoParquet does not support properties that are named such that they
+    > collide with a top-level key.
+    """
+    item = {
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "id": "item1",
+        "properties": {
+            "datetime": "2020-01-01T00:00:00Z",
+            colliding_key: "bogus-value",
+        },
+        "geometry": {"type": "Point", "coordinates": [0, 0]},
+        "links": [],
+        "assets": {"data": {"href": "https://example.com/a.tif"}},
+        "bbox": [0, 0, 0, 0],
+        "collection": "test",
+    }
+
+    with caplog.at_level("WARNING"):
+        table = parse_stac_items_to_arrow([item]).read_all()
+    assert f"properties.{colliding_key}" in caplog.text
+    assert table.schema.names.count(colliding_key) == 1
+
+    # Real-world failure mode: a duped column breaks pyarrow's Dataset schema unification.
+    output_path = tmp_path / "items.parquet"
+    parse_stac_items_to_parquet([item], output_path=output_path)
+
+    dataset = pyarrow.dataset.dataset(str(output_path), format="parquet")
+    assert dataset.schema.names.count(colliding_key) == 1


### PR DESCRIPTION
## Technical Context

- **Related Issues:** N/A, but could open an issue if that helps
- **Breaking Changes:** No - default is to warn

## Description

STAC GeoParquet spec says that,

>STAC GeoParquet does not support properties that are named such that they collide with a top-level key.
>https://radiantearth.github.io/stac-geoparquet-spec/latest/#guidelines

The current implementation will promote properties keys that duplicate top level keys (e.g., I ran into a STAC Item with `properties["collection"]`). This produces a Parquet file that is not up to spec and causes problems when reading the output with code paths like `pyarrow.dataset.Dataset`.

This PR follows the implementation details of `rustac` by defaulting to dropping these properties, with a warning, instead of duplicating them. Users can instead raise an exception by setting the new keyword to `False`. See also `rustac` implementation:

- Warns or errors, https://github.com/stac-utils/rustac/blob/main/crates/core/src/item.rs#L579-L584
- Defaults to true, https://github.com/stac-utils/rustac/blob/972c5b3d6cb29fc791460b94d6ff02e4e2eacb47/crates/core/src/geoarrow/mod.rs#L242-L248

I added this to the lower level functions (`bring_properties_to_top_level`) and plumbed the option up through call sites like the PgSTAC -> STAC-GPQ functions.

---

## Checklist
- [x] **Linting:** Code is formatted and linted
- [x] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [x] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [x] **Documentation:** I have updated `README.md` to reflect any new environment variables, configuration changes, or breaking updates.
- [x] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage
- [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://stac-utils.github.io/ai-contribution-policy). Use of AI tools *must* be indicated.
    - I used Claude to review this PR to help make sure I got all the call sites  

---
> **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.