### PR TITLE
feat: allow injection of pgstac connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a list of changes to `stac-geoparquet`.
 - Drop Python 3.9 (<https://github.com/stac-utils/stac-geoparquet/pull/133>)
 - Fixed resolution of scheme-prefixed `output_path`s (e.g., `s3://bucket/item.parquet`) (<https://github.com/stac-utils/stac-geoparquet/pull/143>)
 - Fixed duplication of STAC Item properties with top-level keys (e.g., "collection") (<https://github.com/stac-utils/stac-geoparquet/pull/144>)
+- Allow users to provide their own PgSTAC connection factory (<https://github.com/stac-utils/stac-geoparquet/pull/145>)
 
 ## 0.8.0
 

--- a/stac_geoparquet/pgstac_reader.py
+++ b/stac_geoparquet/pgstac_reader.py
@@ -131,11 +131,16 @@ def pgstac_dsn(conninfo: str | None, statement_timeout: int | None) -> str:
 
 @contextmanager
 def _connect(
-    conninfo: str | Callable[[], psycopg.Connection],
+    conninfo: str | Callable[[], psycopg.Connection] | None,
     statement_timeout: int | None,
 ) -> Iterator[psycopg.Connection]:
     """
-    Yield a pgstac connection, via connection string or a callable connection factory.
+    Yield a pgstac connection
+
+    This supports:
+    - a connection string
+    - a callable connection factory
+    - an environment variable when set to `None`
 
     If `conninfo` is a callable, users are responsible for setting `search_path`
     (pgstac,public) and `statement_timeout` on the connection themselves.
@@ -149,7 +154,7 @@ def _connect(
 
 
 def pgstac_to_iter(
-    conninfo: str | Callable[[], psycopg.Connection],
+    conninfo: str | Callable[[], psycopg.Connection] | None,
     collection: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
@@ -205,7 +210,7 @@ def pgstac_to_iter(
 
 
 def pgstac_to_arrow(
-    conninfo: str | Callable[[], psycopg.Connection],
+    conninfo: str | Callable[[], psycopg.Connection] | None,
     collection: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
@@ -240,7 +245,7 @@ def pgstac_to_arrow(
 
 
 def pgstac_to_parquet(
-    conninfo: str | Callable[[], psycopg.Connection],
+    conninfo: str | Callable[[], psycopg.Connection] | None,
     output_path: str | Path,
     collection: str | None = None,
     start_datetime: datetime | None = None,
@@ -296,7 +301,7 @@ class Partition:
 
 
 def get_pgstac_partitions(
-    conninfo: str | Callable[[], psycopg.Connection],
+    conninfo: str | Callable[[], psycopg.Connection] | None,
     updated_after: datetime | None = None,
 ) -> Iterator[Partition]:
     with _connect(conninfo, None) as conn:
@@ -333,7 +338,7 @@ def get_pgstac_partitions(
 
 
 def sync_pgstac_to_parquet(
-    conninfo: str | Callable[[], psycopg.Connection],
+    conninfo: str | Callable[[], psycopg.Connection] | None,
     output_path: str | Path,
     updated_after: datetime | None = None,
     chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,

--- a/stac_geoparquet/pgstac_reader.py
+++ b/stac_geoparquet/pgstac_reader.py
@@ -131,21 +131,17 @@ def pgstac_dsn(conninfo: str | None, statement_timeout: int | None) -> str:
 
 @contextmanager
 def _connect(
-    conninfo: str | None,
+    conninfo: str | Callable[[], psycopg.Connection],
     statement_timeout: int | None,
-    conn_factory: Callable[[], psycopg.Connection] | None,
 ) -> Iterator[psycopg.Connection]:
     """
-    Yield a pgstac connection, via connection string or a caller-supplied `conn_factory`.
+    Yield a pgstac connection, via connection string or a callable connection factory.
 
-    Exactly one of the two must be given. `conn_factory` users are responsible for
-    setting `search_path` (pgstac,public) and `statement_timeout` on the connection
-    themselves.
+    If `conninfo` is a callable, users are responsible for setting `search_path`
+    (pgstac,public) and `statement_timeout` on the connection themselves.
     """
-    if (conninfo is None) is (conn_factory is None):
-        raise ValueError("Exactly one of conninfo or conn_factory must be given")
-    if conn_factory is not None:
-        with conn_factory() as conn:
+    if callable(conninfo):
+        with conninfo() as conn:
             yield conn
         return
     with psycopg.connect(pgstac_dsn(conninfo, statement_timeout)) as conn:
@@ -153,7 +149,7 @@ def _connect(
 
 
 def pgstac_to_iter(
-    conninfo: str | None = None,
+    conninfo: str | Callable[[], psycopg.Connection],
     collection: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
@@ -161,7 +157,6 @@ def pgstac_to_iter(
     statement_timeout: int | None = None,
     cursor_itersize: int = 10000,
     row_func: Callable | None = None,
-    conn_factory: Callable[[], psycopg.Connection] | None = None,
 ) -> Iterator[dict[str, Any]]:
     logger.info("Fetching Data from PGStac Into an Iterator of Items")
 
@@ -198,7 +193,7 @@ def pgstac_to_iter(
         query = "SELECT * FROM items;"
         args = ()
     curname = "".join(random.choices(string.ascii_lowercase, k=32))
-    with _connect(conninfo, statement_timeout, conn_factory) as conn:
+    with _connect(conninfo, statement_timeout) as conn:
         with conn.cursor(curname, row_factory=PgstacRowFactory) as cur:  # type: ignore
             cur.itersize = cursor_itersize
             cur.execute(query, args)
@@ -210,7 +205,7 @@ def pgstac_to_iter(
 
 
 def pgstac_to_arrow(
-    conninfo: str | None = None,
+    conninfo: str | Callable[[], psycopg.Connection],
     collection: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
@@ -221,7 +216,6 @@ def pgstac_to_arrow(
     row_func: Callable | None = None,
     tmpdir: str | Path | None = None,
     drop_invalid_properties: bool = True,
-    conn_factory: Callable[[], psycopg.Connection] | None = None,
 ) -> pa.RecordBatchReader:
     """
     Convert pgstac items to an arrow record batch reader.
@@ -235,7 +229,6 @@ def pgstac_to_arrow(
         statement_timeout=statement_timeout,
         cursor_itersize=chunk_size,
         row_func=row_func,
-        conn_factory=conn_factory,
     )
     return parse_stac_items_to_arrow(
         items,
@@ -247,7 +240,7 @@ def pgstac_to_arrow(
 
 
 def pgstac_to_parquet(
-    conninfo: str | None,
+    conninfo: str | Callable[[], psycopg.Connection],
     output_path: str | Path,
     collection: str | None = None,
     start_datetime: datetime | None = None,
@@ -259,7 +252,6 @@ def pgstac_to_parquet(
     row_func: Callable | None = None,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     filesystem: pyarrow.fs.FileSystem | None = None,
-    conn_factory: Callable[[], psycopg.Connection] | None = None,
     **kwargs: Any,
 ) -> str:
     """
@@ -281,7 +273,6 @@ def pgstac_to_parquet(
         statement_timeout=statement_timeout,
         cursor_itersize=chunk_size,
         row_func=row_func,
-        conn_factory=conn_factory,
     )
 
     return parse_stac_items_to_parquet(
@@ -305,11 +296,10 @@ class Partition:
 
 
 def get_pgstac_partitions(
-    conninfo: str | None = None,
+    conninfo: str | Callable[[], psycopg.Connection],
     updated_after: datetime | None = None,
-    conn_factory: Callable[[], psycopg.Connection] | None = None,
 ) -> Iterator[Partition]:
-    with _connect(conninfo, None, conn_factory) as conn:
+    with _connect(conninfo, None) as conn:
         with conn.cursor(row_factory=psycopg.rows.class_row(Partition)) as cur:
             # note: '.000001 seconds' is the minimum resolution for timestamptz in Postgres, so this
             # is added since the inclusive upper bound in the dtrange can be used with exclusive <
@@ -343,7 +333,7 @@ def get_pgstac_partitions(
 
 
 def sync_pgstac_to_parquet(
-    conninfo: str | None,
+    conninfo: str | Callable[[], psycopg.Connection],
     output_path: str | Path,
     updated_after: datetime | None = None,
     chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
@@ -352,7 +342,6 @@ def sync_pgstac_to_parquet(
     row_func: Callable | None = None,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     filesystem: pyarrow.fs.FileSystem | None = None,
-    conn_factory: Callable[[], psycopg.Connection] | None = None,
     **kwargs: Any,
 ) -> str:
     """
@@ -368,7 +357,7 @@ def sync_pgstac_to_parquet(
     logger.info(
         f"Syncing PgSTAC partitions that have been updated since {updated_after} to {output_path} on filesystem {filesystem}."
     )
-    for p in get_pgstac_partitions(conninfo, updated_after, conn_factory=conn_factory):
+    for p in get_pgstac_partitions(conninfo, updated_after):
         of = filedir / p.collection / p.partition
         logger.debug(of)
 
@@ -384,7 +373,6 @@ def sync_pgstac_to_parquet(
             statement_timeout=statement_timeout,
             schema_version=schema_version,
             filesystem=filesystem,
-            conn_factory=conn_factory,
             **kwargs,
         )
     return str(of)

--- a/stac_geoparquet/pgstac_reader.py
+++ b/stac_geoparquet/pgstac_reader.py
@@ -3,6 +3,7 @@ import logging
 import random
 import string
 from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -128,8 +129,31 @@ def pgstac_dsn(conninfo: str | None, statement_timeout: int | None) -> str:
     return psycopg.conninfo.make_conninfo("", **connd)
 
 
-def pgstac_to_iter(
+@contextmanager
+def _connect(
     conninfo: str | None,
+    statement_timeout: int | None,
+    conn_factory: Callable[[], psycopg.Connection] | None,
+) -> Iterator[psycopg.Connection]:
+    """
+    Yield a pgstac connection, via connection string or a caller-supplied `conn_factory`.
+
+    Exactly one of the two must be given. `conn_factory` users are responsible for
+    setting `search_path` (pgstac,public) and `statement_timeout` on the connection
+    themselves.
+    """
+    if (conninfo is None) is (conn_factory is None):
+        raise ValueError("Exactly one of conninfo or conn_factory must be given")
+    if conn_factory is not None:
+        with conn_factory() as conn:
+            yield conn
+        return
+    with psycopg.connect(pgstac_dsn(conninfo, statement_timeout)) as conn:
+        yield conn
+
+
+def pgstac_to_iter(
+    conninfo: str | None = None,
     collection: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
@@ -137,9 +161,9 @@ def pgstac_to_iter(
     statement_timeout: int | None = None,
     cursor_itersize: int = 10000,
     row_func: Callable | None = None,
+    conn_factory: Callable[[], psycopg.Connection] | None = None,
 ) -> Iterator[dict[str, Any]]:
     logger.info("Fetching Data from PGStac Into an Iterator of Items")
-    conninfo = pgstac_dsn(conninfo, statement_timeout)
 
     if search is not None and (
         collection is not None or start_datetime is not None or end_datetime is not None
@@ -174,7 +198,7 @@ def pgstac_to_iter(
         query = "SELECT * FROM items;"
         args = ()
     curname = "".join(random.choices(string.ascii_lowercase, k=32))
-    with psycopg.connect(conninfo) as conn:
+    with _connect(conninfo, statement_timeout, conn_factory) as conn:
         with conn.cursor(curname, row_factory=PgstacRowFactory) as cur:  # type: ignore
             cur.itersize = cursor_itersize
             cur.execute(query, args)
@@ -186,7 +210,7 @@ def pgstac_to_iter(
 
 
 def pgstac_to_arrow(
-    conninfo: str,
+    conninfo: str | None = None,
     collection: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
@@ -197,6 +221,7 @@ def pgstac_to_arrow(
     row_func: Callable | None = None,
     tmpdir: str | Path | None = None,
     drop_invalid_properties: bool = True,
+    conn_factory: Callable[[], psycopg.Connection] | None = None,
 ) -> pa.RecordBatchReader:
     """
     Convert pgstac items to an arrow record batch reader.
@@ -210,6 +235,7 @@ def pgstac_to_arrow(
         statement_timeout=statement_timeout,
         cursor_itersize=chunk_size,
         row_func=row_func,
+        conn_factory=conn_factory,
     )
     return parse_stac_items_to_arrow(
         items,
@@ -221,7 +247,7 @@ def pgstac_to_arrow(
 
 
 def pgstac_to_parquet(
-    conninfo: str,
+    conninfo: str | None,
     output_path: str | Path,
     collection: str | None = None,
     start_datetime: datetime | None = None,
@@ -233,6 +259,7 @@ def pgstac_to_parquet(
     row_func: Callable | None = None,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     filesystem: pyarrow.fs.FileSystem | None = None,
+    conn_factory: Callable[[], psycopg.Connection] | None = None,
     **kwargs: Any,
 ) -> str:
     """
@@ -254,6 +281,7 @@ def pgstac_to_parquet(
         statement_timeout=statement_timeout,
         cursor_itersize=chunk_size,
         row_func=row_func,
+        conn_factory=conn_factory,
     )
 
     return parse_stac_items_to_parquet(
@@ -277,10 +305,11 @@ class Partition:
 
 
 def get_pgstac_partitions(
-    conninfo: str, updated_after: datetime | None = None
+    conninfo: str | None = None,
+    updated_after: datetime | None = None,
+    conn_factory: Callable[[], psycopg.Connection] | None = None,
 ) -> Iterator[Partition]:
-    db = pgstac_dsn(conninfo, None)
-    with psycopg.connect(db) as conn:
+    with _connect(conninfo, None, conn_factory) as conn:
         with conn.cursor(row_factory=psycopg.rows.class_row(Partition)) as cur:
             # note: '.000001 seconds' is the minimum resolution for timestamptz in Postgres, so this
             # is added since the inclusive upper bound in the dtrange can be used with exclusive <
@@ -314,7 +343,7 @@ def get_pgstac_partitions(
 
 
 def sync_pgstac_to_parquet(
-    conninfo: str,
+    conninfo: str | None,
     output_path: str | Path,
     updated_after: datetime | None = None,
     chunk_size: int = DEFAULT_JSON_CHUNK_SIZE,
@@ -323,6 +352,7 @@ def sync_pgstac_to_parquet(
     row_func: Callable | None = None,
     schema_version: SUPPORTED_PARQUET_SCHEMA_VERSIONS = DEFAULT_PARQUET_SCHEMA_VERSION,
     filesystem: pyarrow.fs.FileSystem | None = None,
+    conn_factory: Callable[[], psycopg.Connection] | None = None,
     **kwargs: Any,
 ) -> str:
     """
@@ -338,7 +368,7 @@ def sync_pgstac_to_parquet(
     logger.info(
         f"Syncing PgSTAC partitions that have been updated since {updated_after} to {output_path} on filesystem {filesystem}."
     )
-    for p in get_pgstac_partitions(conninfo, updated_after):
+    for p in get_pgstac_partitions(conninfo, updated_after, conn_factory=conn_factory):
         of = filedir / p.collection / p.partition
         logger.debug(of)
 
@@ -354,6 +384,7 @@ def sync_pgstac_to_parquet(
             statement_timeout=statement_timeout,
             schema_version=schema_version,
             filesystem=filesystem,
+            conn_factory=conn_factory,
             **kwargs,
         )
     return str(of)

--- a/tests/test_pgstac_reader.py
+++ b/tests/test_pgstac_reader.py
@@ -3,7 +3,9 @@ import pathlib
 from datetime import datetime
 
 import docker
+import psycopg
 import pyarrow.fs
+import pyarrow.parquet
 import pypgstac
 import pytest
 from pypgstac.db import PgstacDB
@@ -21,6 +23,15 @@ HERE = pathlib.Path(__file__).parent
 
 DOCKERIMG = "ghcr.io/stac-utils/pgstac:latest"
 NAIPDATA = HERE / "data" / "naip-pc.json"
+
+
+def test_connect_requires_exactly_one_of_conninfo_or_conn_factory():
+    with pytest.raises(ValueError):
+        with pgstac_reader._connect(None, None, None):
+            pass
+    with pytest.raises(ValueError):
+        with pgstac_reader._connect("postgres://unused", None, lambda: None):
+            pass
 
 
 def test_sync_pgstac_to_parquet_with_scheme_prefixed_output_path(tmp_path, monkeypatch):
@@ -148,3 +159,22 @@ def test_pgstac_reader_arrow(pgstac_postgres):
     assert items.schema.field("id").name == "id"
     assert items.schema.field("id").type == "string"
     assert items.schema.field("geometry").name == "geometry"
+
+
+def test_sync_pgstac_to_parquet_with_conn_factory(pgstac_postgres, tmp_path):
+    """
+    conn_factory should work as a drop-in alternative to conninfo, threaded through
+    sync_pgstac_to_parquet -> get_pgstac_partitions and -> pgstac_to_parquet.
+    """
+    filesystem = pyarrow.fs.LocalFileSystem()
+
+    written = pgstac_reader.sync_pgstac_to_parquet(
+        None,
+        str(tmp_path / "root"),
+        conn_factory=lambda: psycopg.connect(pgstac_postgres),
+        filesystem=filesystem,
+    )
+
+    table = pyarrow.parquet.read_table(written, filesystem=filesystem)
+    assert table.num_rows == 4
+    assert set(table.column("collection").to_pylist()) == {"naip"}

--- a/tests/test_pgstac_reader.py
+++ b/tests/test_pgstac_reader.py
@@ -25,15 +25,6 @@ DOCKERIMG = "ghcr.io/stac-utils/pgstac:latest"
 NAIPDATA = HERE / "data" / "naip-pc.json"
 
 
-def test_connect_requires_exactly_one_of_conninfo_or_conn_factory():
-    with pytest.raises(ValueError):
-        with pgstac_reader._connect(None, None, None):
-            pass
-    with pytest.raises(ValueError):
-        with pgstac_reader._connect("postgres://unused", None, lambda: None):
-            pass
-
-
 def test_sync_pgstac_to_parquet_with_scheme_prefixed_output_path(tmp_path, monkeypatch):
     """
     Regression test for output path mangling in `sync_pgstac_to_parquet`
@@ -163,15 +154,16 @@ def test_pgstac_reader_arrow(pgstac_postgres):
 
 def test_sync_pgstac_to_parquet_with_conn_factory(pgstac_postgres, tmp_path):
     """
-    conn_factory should work as a drop-in alternative to conninfo, threaded through
-    sync_pgstac_to_parquet -> get_pgstac_partitions and -> pgstac_to_parquet.
+    conninfo can be provided as a Callable.
+
+    This test exercises the `_connect` function while also threading through the call
+    stack of sync_pgstac_to_parquet -> get_pgstac_partitions -> pgstac_to_parquet.
     """
     filesystem = pyarrow.fs.LocalFileSystem()
 
     written = pgstac_reader.sync_pgstac_to_parquet(
-        None,
+        lambda: psycopg.connect(pgstac_postgres),
         str(tmp_path / "root"),
-        conn_factory=lambda: psycopg.connect(pgstac_postgres),
         filesystem=filesystem,
     )
 


### PR DESCRIPTION
## Technical Context
- **Related Issues:** N/A but can create if it helps
- **Breaking Changes:** No - existing code should "just work" since new kwarg is 

## Description

This PR adds a new keyword argument to PgSTAC related functions allowing a user to control the connection details. This should be useful generally (e.g., using a connection pool), but specifically came up in resolving using this code to connect to PgSTAC hosted behind a RDS Proxy:

>FATAL: Feature not supported: RDS Proxy currently doesn't support command-line options

This PR resolves this by giving more control for the connection to users with a small downside of needing more ownership (e.g., setting `search_path`, see `_connect` docstring). This should be backwards compatible.

---

## Checklist
- [x] **Linting:** Code is formatted and linted
- [x] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [x] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [x] **Documentation:** I have updated `README.md` to reflect any new environment variables, configuration changes, or breaking updates.
- [x] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage
- [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://stac-utils.github.io/ai-contribution-policy). Use of AI tools *must* be indicated.
    - I used Claude to help review this before submitting

---
> **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.